### PR TITLE
Invitations should all include a `Smartphone`

### DIFF
--- a/lib/blocs/app_bloc.dart
+++ b/lib/blocs/app_bloc.dart
@@ -24,9 +24,7 @@ class StudyAppBLoC {
 
   get stateStream => _stateStream;
 
-  List<ActiveParticipationInvitation> _invitations = [];
-  set invitations(value) => _invitations = value;
-  get invitations => _invitations;
+  List<ActiveParticipationInvitation> invitations = [];
 
   List<Message> _messages = [];
   final StreamController<int> _messageStreamController =

--- a/lib/view_models/invitations_list_model.dart
+++ b/lib/view_models/invitations_list_model.dart
@@ -13,7 +13,7 @@ class InvitationsListViewModel extends ViewModel {
         .where((invitation) =>
             invitation.assignedDevices
                 ?.any((device) => device.device is Smartphone) ??
-            true)
+            false)
         .toList();
 
     return bloc.invitations;

--- a/lib/view_models/invitations_list_model.dart
+++ b/lib/view_models/invitations_list_model.dart
@@ -4,6 +4,18 @@ class InvitationsListViewModel extends ViewModel {
   Future<List<ActiveParticipationInvitation>> get invitations async {
     bloc.invitations =
         await CarpParticipationService().getActiveParticipationInvitations();
+
+    /// Filter the invitations to only include those that
+    /// have a smartphone as a device in [ActiveParticipationInvitation.assignedDevices] list
+    /// (i.e. the invitation is for a smartphone).
+    /// This is done to avoid showing invitations for other devices (e.g. [WebBrowser]).
+    bloc.invitations = bloc.invitations
+        .where((invitation) =>
+            invitation.assignedDevices
+                ?.any((device) => device.device is Smartphone) ??
+            true)
+        .toList();
+
     return bloc.invitations;
   }
 


### PR DESCRIPTION
For example, the ICAT study had only a `WebBrowser` device, therefore should not be shown in the study app.
Fixes #177