### PR TITLE
feat: migrate to CAMS 2.x (API level 2.0)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
         "--dart-define",
         "deployment-mode=dev",
         "--dart-define",
-        "debug-level=none"
+        "debug-level=debug"
       ],
       "flutterMode": "debug"
     },

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,10 +1,39 @@
 PODS:
-  - audio_streamer (0.0.1):
+  - AppAuth (2.0.0):
+    - AppAuth/Core (= 2.0.0)
+    - AppAuth/ExternalUserAgent (= 2.0.0)
+  - AppAuth/Core (2.0.0)
+  - AppAuth/ExternalUserAgent (2.0.0):
+    - AppAuth/Core
+  - "appcheck (1.5.4+1)":
+    - Flutter
+  - audio_session (0.0.1):
+    - Flutter
+  - audio_streamer (4.3.0):
+    - Flutter
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - battery_plus (1.0.0):
+    - Flutter
+  - camera_avfoundation (0.0.1):
+    - Flutter
+  - connectivity_plus (0.0.1):
     - Flutter
   - dchs_flutter_beacon (0.6.5):
     - Flutter
+  - device_info_plus (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_activity_recognition (0.0.1):
+    - Flutter
+  - flutter_appauth (0.0.1):
+    - AppAuth (= 2.0.0)
+    - Flutter
+  - flutter_blue_plus_darwin (0.0.2):
+    - Flutter
+    - FlutterMacOS
+  - flutter_local_notifications (0.0.1):
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
@@ -12,9 +41,16 @@ PODS:
     - Flutter
     - flutter_sound_core (= 9.30.0)
   - flutter_sound_core (9.30.0)
+  - flutter_timezone (0.0.1):
+    - Flutter
   - flutter_web_auth_2 (3.0.0):
     - Flutter
-  - health (12.2.1):
+  - health (13.3.1):
+    - Flutter
+  - just_audio (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - light (4.1.1):
     - Flutter
   - location (0.0.1):
     - Flutter
@@ -23,45 +59,89 @@ PODS:
     - Movesense
     - SwiftProtobuf
   - Movesense (3.33.1)
+  - network_info_plus (0.0.1):
+    - Flutter
   - oidc_ios (0.0.1):
     - Flutter
   - open_settings_plus (0.0.1):
+    - Flutter
+  - package_info_plus (0.4.5):
+    - Flutter
+  - pedometer (4.2.0):
     - Flutter
   - permission_handler_apple (9.3.0):
     - Flutter
   - polar (0.0.1):
     - Flutter
-    - PolarBleSdk (~> 6.1.0)
-  - PolarBleSdk (6.1.0):
+    - PolarBleSdk (= 6.14.0)
+  - PolarBleSdk (6.14.0):
     - RxSwift (~> 6.8.0)
     - SwiftProtobuf (~> 1.0)
     - Zip (~> 2.1.2)
-  - RxSwift (6.8.0)
-  - screen_state (1.0.0):
+  - qr_code_scanner_plus (0.2.6):
     - Flutter
+  - RxSwift (6.8.0)
+  - screen_state (5.0.0):
+    - Flutter
+  - sensors_plus (0.0.1):
+    - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
   - SwiftProtobuf (1.33.3)
+  - url_launcher_ios (0.0.1):
+    - Flutter
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - Zip (2.1.2)
 
 DEPENDENCIES:
+  - appcheck (from `.symlinks/plugins/appcheck/ios`)
+  - audio_session (from `.symlinks/plugins/audio_session/ios`)
   - audio_streamer (from `.symlinks/plugins/audio_streamer/ios`)
+  - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
+  - battery_plus (from `.symlinks/plugins/battery_plus/ios`)
+  - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - dchs_flutter_beacon (from `.symlinks/plugins/dchs_flutter_beacon/ios`)
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_activity_recognition (from `.symlinks/plugins/flutter_activity_recognition/ios`)
+  - flutter_appauth (from `.symlinks/plugins/flutter_appauth/ios`)
+  - flutter_blue_plus_darwin (from `.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
+  - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - health (from `.symlinks/plugins/health/ios`)
+  - just_audio (from `.symlinks/plugins/just_audio/darwin`)
+  - light (from `.symlinks/plugins/light/ios`)
   - location (from `.symlinks/plugins/location/ios`)
   - mdsflutter (from `.symlinks/plugins/mdsflutter/ios`)
   - Movesense (from `https://bitbucket.org/movesense/movesense-mobile-lib/`)
+  - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
   - oidc_ios (from `.symlinks/plugins/oidc_ios/ios`)
   - open_settings_plus (from `.symlinks/plugins/open_settings_plus/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - pedometer (from `.symlinks/plugins/pedometer/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - polar (from `.symlinks/plugins/polar/ios`)
+  - qr_code_scanner_plus (from `.symlinks/plugins/qr_code_scanner_plus/ios`)
   - screen_state (from `.symlinks/plugins/screen_state/ios`)
+  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 SPEC REPOS:
   trunk:
+    - AppAuth
     - flutter_sound_core
     - PolarBleSdk
     - RxSwift
@@ -69,38 +149,82 @@ SPEC REPOS:
     - Zip
 
 EXTERNAL SOURCES:
+  appcheck:
+    :path: ".symlinks/plugins/appcheck/ios"
+  audio_session:
+    :path: ".symlinks/plugins/audio_session/ios"
   audio_streamer:
     :path: ".symlinks/plugins/audio_streamer/ios"
+  audioplayers_darwin:
+    :path: ".symlinks/plugins/audioplayers_darwin/darwin"
+  battery_plus:
+    :path: ".symlinks/plugins/battery_plus/ios"
+  camera_avfoundation:
+    :path: ".symlinks/plugins/camera_avfoundation/ios"
+  connectivity_plus:
+    :path: ".symlinks/plugins/connectivity_plus/ios"
   dchs_flutter_beacon:
     :path: ".symlinks/plugins/dchs_flutter_beacon/ios"
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
   flutter_activity_recognition:
     :path: ".symlinks/plugins/flutter_activity_recognition/ios"
+  flutter_appauth:
+    :path: ".symlinks/plugins/flutter_appauth/ios"
+  flutter_blue_plus_darwin:
+    :path: ".symlinks/plugins/flutter_blue_plus_darwin/darwin"
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   flutter_sound:
     :path: ".symlinks/plugins/flutter_sound/ios"
+  flutter_timezone:
+    :path: ".symlinks/plugins/flutter_timezone/ios"
   flutter_web_auth_2:
     :path: ".symlinks/plugins/flutter_web_auth_2/ios"
   health:
     :path: ".symlinks/plugins/health/ios"
+  just_audio:
+    :path: ".symlinks/plugins/just_audio/darwin"
+  light:
+    :path: ".symlinks/plugins/light/ios"
   location:
     :path: ".symlinks/plugins/location/ios"
   mdsflutter:
     :path: ".symlinks/plugins/mdsflutter/ios"
   Movesense:
     :git: https://bitbucket.org/movesense/movesense-mobile-lib/
+  network_info_plus:
+    :path: ".symlinks/plugins/network_info_plus/ios"
   oidc_ios:
     :path: ".symlinks/plugins/oidc_ios/ios"
   open_settings_plus:
     :path: ".symlinks/plugins/open_settings_plus/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
+  pedometer:
+    :path: ".symlinks/plugins/pedometer/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   polar:
     :path: ".symlinks/plugins/polar/ios"
+  qr_code_scanner_plus:
+    :path: ".symlinks/plugins/qr_code_scanner_plus/ios"
   screen_state:
     :path: ".symlinks/plugins/screen_state/ios"
+  sensors_plus:
+    :path: ".symlinks/plugins/sensors_plus/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 CHECKOUT OPTIONS:
   Movesense:
@@ -108,26 +232,49 @@ CHECKOUT OPTIONS:
     :git: https://bitbucket.org/movesense/movesense-mobile-lib/
 
 SPEC CHECKSUMS:
-  audio_streamer: 2e472b9f81cec5e381c4cf7667afa3055dcb45a4
+  AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
+  appcheck: 3c94d0ffc94bd639938cac7427d5b13df2795404
+  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
+  audio_streamer: 85e5b27e443525fcfe375052132327539c89d19a
+  audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
+  battery_plus: b42253f6d2dde71712f8c36fef456d99121c5977
+  camera_avfoundation: 5675ca25298b6f81fa0a325188e7df62cc217741
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   dchs_flutter_beacon: 88d72cc467de508d621e454ea66c6231d0897d4c
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_activity_recognition: 52dfad4c1e9cec99f0841b3ed0efcc9d424b3deb
+  flutter_appauth: d4abcf54856e5d8ba82ed7646ffc83245d4aa448
+  flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
+  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   flutter_sound: d95194f6476c9ad211d22b3a414d852c12c7ca44
   flutter_sound_core: 7f2626d249d3a57bfa6da892ef7e22d234482c1a
+  flutter_timezone: 7c838e17ffd4645d261e87037e5bebf6d38fe544
   flutter_web_auth_2: 5c8d9dcd7848b5a9efb086d24e7a9adcae979c80
-  health: fe206e65f13a9b88623605fbd8af8f029e23dc35
+  health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
+  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  light: 6490592116da81837a414ef49387bbea7a5ed375
   location: 155caecf9da4f280ab5fe4a55f94ceccfab838f8
   mdsflutter: bd3c0b3335d50947d1a192cf70f930e0fb04a766
   Movesense: dc64047c1feb856b7f7ac6ea2c67685350d99dd5
+  network_info_plus: cf61925ab5205dce05a4f0895989afdb6aade5fc
   oidc_ios: 16966cad509ce6850ca4ca1216c5138bef2a8726
   open_settings_plus: d19f91e8a04649358a51c19b484ce2e637149d70
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  pedometer: 6806036696085739f36b4e4e5374135e86220a59
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  polar: 0374f6063ade7e2dd85d626f87cbe2393d3eda7c
-  PolarBleSdk: bfb57cf8350f0c53d441b8632ba6df363ce7c79f
+  polar: e6c15a5007d85ab02ce12973c152545bcba861cd
+  PolarBleSdk: 1d56bb7a3ca0a6df04cb4f652fdccb26064df011
+  qr_code_scanner_plus: 1fb59fd4576edb53ec7560c3746f454dee54300c
   RxSwift: 4e28be97cbcfeee614af26d83415febbf2bf6f45
-  screen_state: 52d6e997d31bddba6417c60d9cdd22effd0320a7
+  screen_state: 05272c0afc6270e43f08589598234334698b53ae
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftProtobuf: e1b437c8e31a4c5577b643249a0bb62ed4f02153
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
   Zip: b3fef584b147b6e582b2256a9815c897d60ddc67
 
 PODFILE CHECKSUM: 45842edf150243fea66883d4dfad1e5ddb428147

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "appauth-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openid/AppAuth-iOS",
-      "state" : {
-        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
-        "version" : "2.0.0"
-      }
-    },
-    {
       "identity" : "phonenumberkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit.git",

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "appauth-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openid/AppAuth-iOS",
-      "state" : {
-        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
-        "version" : "2.0.0"
-      }
-    },
-    {
       "identity" : "phonenumberkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/marmelroy/PhoneNumberKit.git",

--- a/lib/blocs/app_bloc.dart
+++ b/lib/blocs/app_bloc.dart
@@ -91,9 +91,11 @@ class StudyAppBLoC extends ChangeNotifier {
     const deb = String.fromEnvironment('debug-level', defaultValue: 'info');
     debugLevel = DebugLevel.values.where((element) => element.name == deb).first;
 
-    info('$runtimeType created. '
-        'DeploymentMode: ${deploymentMode.name}, '
-        'DebugLevel: ${debugLevel.name}');
+    info(
+      '$runtimeType created. '
+      'DeploymentMode: ${deploymentMode.name}, '
+      'DebugLevel: ${debugLevel.name}',
+    );
   }
 
   LocalizationManager get localizationManager =>
@@ -215,10 +217,12 @@ class StudyAppBLoC extends ChangeNotifier {
     if (deploymentMode != DeploymentMode.local) return;
 
     if (hasStudyBeenDeployed) {
-      info('Running in local deployment mode. Note that the local protocol has '
-          'already been deployed and the cached version will be loaded and used. '
-          'If you want to reload a modified protocol, delete the app with the '
-          'cached protocol from the phone before running it.');
+      info(
+        'Running in local deployment mode. Note that the local protocol has '
+        'already been deployed and the cached version will be loaded and used. '
+        'If you want to reload a modified protocol, delete the app with the '
+        'cached protocol from the phone before running it.',
+      );
     } else {
       debug('$runtimeType - deploying local protocol');
 
@@ -229,17 +233,17 @@ class StudyAppBLoC extends ChangeNotifier {
       // Deploy this protocol using the on-phone deployment service.
       final status = await SmartphoneDeploymentService().createStudyDeployment(protocol!);
 
+      // The primary device (the smartphone) is found in the device status list.
+      final primaryDeviceRoleName = status.deviceStatusList
+          .firstWhere((deviceStatus) => deviceStatus.device is PrimaryDeviceConfiguration)
+          .device
+          .roleName;
+
       // Save the participant and study on the phone for use across app restart.
-      var participant = Participant(
-        studyDeploymentId: status.studyDeploymentId,
-        deviceRoleName: status.primaryDeviceStatus?.device.roleName,
-      );
+      var participant = Participant(studyDeploymentId: status.studyDeploymentId, deviceRoleName: primaryDeviceRoleName);
       LocalSettings().participant = participant;
 
-      bloc.study = SmartphoneStudy(
-        studyDeploymentId: status.studyDeploymentId,
-        deviceRoleName: status.primaryDeviceStatus!.device.roleName,
-      );
+      bloc.study = SmartphoneStudy(studyDeploymentId: status.studyDeploymentId, deviceRoleName: primaryDeviceRoleName);
     }
   }
 
@@ -247,10 +251,7 @@ class StudyAppBLoC extends ChangeNotifier {
   ///
   /// If a [context] is provided, the translation for this study is re-loaded
   /// and applied in the app.
-  void setStudyInvitation(
-    ActiveParticipationInvitation invitation, [
-    BuildContext? context,
-  ]) {
+  void setStudyInvitation(ActiveParticipationInvitation invitation, [BuildContext? context]) {
     // create and save the participant info based on this invitation
     var participant = Participant.fromParticipationInvitation(invitation);
     LocalSettings().participant = participant;
@@ -308,23 +309,15 @@ class StudyAppBLoC extends ChangeNotifier {
       (deployment == null) ? [] : await participationService.getParticipantDataList([deployment!.studyDeploymentId]);
 
   /// Set the participant data for this study.
-  void setParticipantData(
-    String studyDeploymentId,
-    Map<String, Data> data, [
-    String? inputByParticipantRole,
-  ]) =>
-      participationService.setParticipantData(
-        studyDeploymentId,
-        data,
-        inputByParticipantRole,
-      );
+  void setParticipantData(String studyDeploymentId, Map<String, Data> data, [String? inputByParticipantRole]) =>
+      participationService.setParticipantData(studyDeploymentId, data, inputByParticipantRole);
 
   /// Does this app use location permissions?
   bool get usingLocationPermissions => true;
 
   /// Get the informed consent for this study.
   Future<RPOrderedTask?> getInformedConsent({bool refresh = false}) =>
-      informedConsentManager.getInformedConsent(refresh: refresh);
+      informedConsentManager.getConsentDocument(refresh: refresh);
 
   /// Has the informed consent been accepted by the user?
   ///
@@ -386,10 +379,13 @@ class StudyAppBLoC extends ChangeNotifier {
   /// Does this [deployment] have any measures?
   bool hasMeasures() => (deployment == null)
       ? false
-      : (deployment!.measures.any((measure) => (measure.type != SurveyUserTask.VIDEO_TYPE &&
-          measure.type != SurveyUserTask.IMAGE_TYPE &&
-          measure.type != SurveyUserTask.AUDIO_TYPE &&
-          measure.type != SurveyUserTask.SURVEY_TYPE)));
+      : (deployment!.measures.any(
+          (measure) =>
+              (measure.type != AppTask.VIDEO_TYPE &&
+              measure.type != AppTask.IMAGE_TYPE &&
+              measure.type != AppTask.AUDIO_TYPE &&
+              measure.type != AppTask.SURVEY_TYPE),
+        ));
 
   /// Does this [deployment] have the measure of type [type]?
   bool hasMeasure(String type) {
@@ -425,11 +421,11 @@ class StudyAppBLoC extends ChangeNotifier {
   /// Start sensing.
   Future<void> start() async {
     assert(Sensing().controller != null, 'No Study Controller - the study has not been deployed.');
-    if (!Sensing().isRunning) Sensing().controller?.start();
+    if (!Sensing().isRunning) Sensing().controller?.resume();
   }
 
   /// Stop sensing.
-  void stop() => Sensing().controller?.stop();
+  void stop() => Sensing().controller?.pause();
 
   /// Dispose the entire sensing.
   @override

--- a/lib/blocs/sensing.dart
+++ b/lib/blocs/sensing.dart
@@ -21,8 +21,8 @@ part of carp_study_app;
 class Sensing {
   static final Sensing _instance = Sensing._();
   StudyDeploymentStatus? _status;
-  SmartphoneDeploymentController? _controller;
-  Study? _study;
+  SmartphoneStudyController? _controller;
+  SmartphoneStudy? _study;
 
   /// The deployment service used in this app.
   DeploymentService get deploymentService =>
@@ -30,7 +30,7 @@ class Sensing {
 
   /// The study running on this phone.
   /// Only available after [addStudy] is called.
-  Study? get study => _study;
+  SmartphoneStudy? get study => _study;
 
   /// The deployment running on this phone.
   /// Only available after [addStudy] is called.
@@ -46,10 +46,10 @@ class Sensing {
   String? get studyDeploymentId => _study?.studyDeploymentId;
 
   /// The study runtime for this deployment.
-  SmartphoneDeploymentController? get controller => _controller;
+  SmartphoneStudyController? get controller => _controller;
 
-  /// Is sensing running, i.e. has the study executor been started?
-  bool get isRunning => (controller != null) && controller!.executor.state == ExecutorState.started;
+  /// Is sensing running, i.e. has the study executor been resumed?
+  bool get isRunning => (controller != null) && controller!.executor.state == ExecutorState.Resumed;
 
   /// The list of running - i.e. used - probes in this study.
   List<Probe> get runningProbes => (_controller != null) ? _controller!.executor.probes : [];
@@ -60,12 +60,9 @@ class Sensing {
   /// current deployment. Hence, this method returns the list of device managers
   /// used in the current deployment.
   List<DeviceManager> get deploymentDevices => deployment != null
-      ? SmartPhoneClientManager()
-          .deviceController
-          .devices
-          .values
-          .where((manager) => deployment!.devices.any((element) => element.type == manager.type))
-          .toList()
+      ? SmartPhoneClientManager().deviceController.devices.values
+            .where((manager) => deployment!.devices.any((element) => element.type == manager.deviceType))
+            .toList()
       : [];
 
   /// The smartphone (primary device) manager.
@@ -111,7 +108,7 @@ class Sensing {
     // Create and configure a client manager for this phone
     await SmartPhoneClientManager().configure(
       deploymentService: deploymentService,
-      deviceController: DeviceController(),
+      dataCollectorFactory: DeviceController(),
 
       // Need to ask for permissions all at once on Android.
       askForPermissions: Platform.isAndroid ? true : false,
@@ -120,37 +117,35 @@ class Sensing {
     info('$runtimeType initialized');
   }
 
-  /// Add and deploy the study, and configure the study runtime (sampling).
+  /// Add the study to the client manager and deploy it.
   Future<StudyStatus> addStudy() async {
-    assert(SmartPhoneClientManager().isConfigured,
-        'The client manager is not yet configured. Call SmartPhoneClientManager().configure() before adding a study.');
+    assert(
+      SmartPhoneClientManager().isConfigured,
+      'The client manager is not yet configured. Call SmartPhoneClientManager().configure() before adding a study.',
+    );
     assert(bloc.study != null, 'No study is provided. Cannot start deployment w/o a study.');
 
     _study = await SmartPhoneClientManager().addStudy(bloc.study!);
 
-    _controller = SmartPhoneClientManager().getStudyRuntime(study!.studyDeploymentId);
-
     return await tryDeployment();
   }
 
-  ///7 Try to deploy the study.
+  /// Try to deploy the study.
   ///
   /// Note that if the study has already been deployed on this phone it has
   /// been cached locally and the local version will be used pr. default.
-  /// If not deployed before (i.e., cached) the study deployment will be
-  /// fetched from the deployment service.
+  /// If not deployed before the study deployment will be fetched from the
+  /// deployment service.
   Future<StudyStatus> tryDeployment() async {
-    assert(controller != null, 'No study or controller is provided. Cannot start deployment w/o a study.');
+    assert(study != null, 'No study is provided. Cannot deploy w/o a study. Call addStudy() first.');
 
-    StudyStatus status = await controller!.tryDeployment(useCached: true);
+    StudyStatus status = await SmartPhoneClientManager().tryDeployment(study!.studyDeploymentId, study!.deviceRoleName);
+
+    _controller = SmartPhoneClientManager().getStudyController(_study!);
 
     translateStudyProtocol();
 
-    await controller?.configure();
-
-    // Mirror each measurement to the console only when CAMS debug logging is on
-    // — matches the gating in carp_mobile_sensing's debug()/info() helpers so a
-    // release build (or any non-debug level) doesn't get spammed.
+    // Mirror each measurement to the console only in debug to avoid spamming logs.
     if (Settings().debugLevel.index >= DebugLevel.debug.index) {
       controller?.measurements.listen((measurement) => debugPrint(toJsonString(measurement)));
     }
@@ -161,17 +156,7 @@ class Sensing {
 
   Future<void> removeStudy() async {
     if (study == null) return;
-    // SmartPhoneClientManager.removeStudy calls getStudyRuntime which does an
-    // unsafe `as SmartphoneDeploymentController` cast — it throws when the
-    // study was never added to the client manager (e.g. the user cancelled
-    // consent before configureStudy ran). Swallow that case; we just want
-    // the study gone, and it never existed here.
-    try {
-      await SmartPhoneClientManager().removeStudy(study!.studyDeploymentId);
-    } on TypeError {
-      info('$runtimeType - study $study was never registered with the '
-          'client manager, skipping removeStudy.');
-    }
+    await SmartPhoneClientManager().removeStudy(study!.studyDeploymentId, study!.deviceRoleName);
   }
 
   /// Get the last known status for the current study deployment.
@@ -192,8 +177,8 @@ class Sensing {
     // Fast out is no localization
     if (bloc.localization == null) return;
 
-    // Fast out, if not configured or no protocol
-    if (controller?.status != StudyStatus.Deployed || controller?.deployment == null) {
+    // Fast out, if not configured or no protocol.
+    if (study?.status != StudyStatus.Deployed || controller?.deployment == null) {
       return;
     }
 

--- a/lib/blocs/sensing.dart
+++ b/lib/blocs/sensing.dart
@@ -145,11 +145,6 @@ class Sensing {
 
     translateStudyProtocol();
 
-    // Mirror each measurement to the console only in debug to avoid spamming logs.
-    if (Settings().debugLevel.index >= DebugLevel.debug.index) {
-      controller?.measurements.listen((measurement) => debugPrint(toJsonString(measurement)));
-    }
-
     info('$runtimeType - Study added, deployment id: $studyDeploymentId');
     return status;
   }

--- a/lib/carp_study_app.dart
+++ b/lib/carp_study_app.dart
@@ -33,14 +33,9 @@ class CarpStudyAppState extends State<CarpStudyApp> {
     errorBuilder: (context, state) => const ErrorPage(),
     redirect: (context, state) async {
       final loc = state.matchedLocation;
-      debugPrint(
-        '[redirect] loc=$loc auth=${bloc.backend.isAuthenticated} '
-        'studyDeployed=${bloc.hasStudyBeenDeployed}',
-      );
 
       // 1) Not authenticated → login page.
       if (bloc.deploymentMode != DeploymentMode.local && !bloc.backend.isAuthenticated) {
-        debugPrint('[redirect] → /login (not authenticated)');
         return LoginPage.route;
       }
 
@@ -48,15 +43,12 @@ class CarpStudyAppState extends State<CarpStudyApp> {
       // details page). Anywhere else gets bounced to the list.
       if (!bloc.hasStudyBeenDeployed) {
         if (loc == InvitationListPage.route || loc.startsWith('${InvitationDetailsPage.route}/')) {
-          debugPrint('[redirect] → null (already on invitation route)');
           return null;
         }
-        debugPrint('[redirect] → /invitations (no study)');
         return InvitationListPage.route;
       }
 
       // 3) Fully onboarded.
-      debugPrint('[redirect] → null (fully onboarded)');
       return null;
     },
     routes: <RouteBase>[

--- a/lib/carp_study_app.dart
+++ b/lib/carp_study_app.dart
@@ -33,8 +33,10 @@ class CarpStudyAppState extends State<CarpStudyApp> {
     errorBuilder: (context, state) => const ErrorPage(),
     redirect: (context, state) async {
       final loc = state.matchedLocation;
-      debugPrint('[redirect] loc=$loc auth=${bloc.backend.isAuthenticated} '
-          'studyDeployed=${bloc.hasStudyBeenDeployed}');
+      debugPrint(
+        '[redirect] loc=$loc auth=${bloc.backend.isAuthenticated} '
+        'studyDeployed=${bloc.hasStudyBeenDeployed}',
+      );
 
       // 1) Not authenticated → login page.
       if (bloc.deploymentMode != DeploymentMode.local && !bloc.backend.isAuthenticated) {
@@ -64,18 +66,12 @@ class CarpStudyAppState extends State<CarpStudyApp> {
         routes: [
           // Home is just a landing slot — the top-level redirect always moves
           // the user to the right place based on bloc state.
-          GoRoute(
-            path: homeRoute,
-            parentNavigatorKey: _shellNavigatorKey,
-            redirect: (_, __) => StudyPage.route,
-          ),
+          GoRoute(path: homeRoute, parentNavigatorKey: _shellNavigatorKey, redirect: (_, _) => StudyPage.route),
           GoRoute(
             path: TaskListPage.route,
             parentNavigatorKey: _shellNavigatorKey,
             pageBuilder: (context, state) => CustomTransitionPage(
-              child: TaskListPage(
-                model: bloc.appViewModel.taskListPageViewModel,
-              ),
+              child: TaskListPage(model: bloc.appViewModel.taskListPageViewModel),
               transitionsBuilder: bottomNavigationBarAnimation,
             ),
           ),
@@ -83,9 +79,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
             path: StudyPage.route,
             parentNavigatorKey: _shellNavigatorKey,
             pageBuilder: (context, state) => CustomTransitionPage(
-              child: StudyPage(
-                model: bloc.appViewModel.studyPageViewModel,
-              ),
+              child: StudyPage(model: bloc.appViewModel.studyPageViewModel),
               transitionsBuilder: bottomNavigationBarAnimation,
             ),
             routes: [
@@ -95,9 +89,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
               GoRoute(
                 path: 'consent',
                 parentNavigatorKey: _rootNavigatorKey,
-                builder: (context, state) => InformedConsentPage(
-                  model: bloc.appViewModel.informedConsentViewModel,
-                ),
+                builder: (context, state) => InformedConsentPage(model: bloc.appViewModel.informedConsentViewModel),
               ),
             ],
           ),
@@ -112,10 +104,8 @@ class CarpStudyAppState extends State<CarpStudyApp> {
           GoRoute(
             path: DeviceListPage.route,
             parentNavigatorKey: _shellNavigatorKey,
-            pageBuilder: (context, state) => const CustomTransitionPage(
-              child: DeviceListPage(),
-              transitionsBuilder: bottomNavigationBarAnimation,
-            ),
+            pageBuilder: (context, state) =>
+                const CustomTransitionPage(child: DeviceListPage(), transitionsBuilder: bottomNavigationBarAnimation),
           ),
           GoRoute(
             path: ProfilePage.route,
@@ -130,9 +120,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
       GoRoute(
         path: StudyDetailsPage.route,
         parentNavigatorKey: _rootNavigatorKey,
-        builder: (context, state) => StudyDetailsPage(
-          model: bloc.appViewModel.studyPageViewModel,
-        ),
+        builder: (context, state) => StudyDetailsPage(model: bloc.appViewModel.studyPageViewModel),
       ),
       GoRoute(
         path: ParticipantDataPage.route,
@@ -178,10 +166,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
   /// Research Package translations, incl. both local language assets plus
   /// translations of informed consent and surveys downloaded from CARP
   final RPLocalizationsDelegate rpLocalizationsDelegate = RPLocalizationsDelegate(
-    loaders: [
-      const AssetLocalizationLoader(),
-      bloc.localizationLoader,
-    ],
+    loaders: [const AssetLocalizationLoader(), bloc.localizationLoader],
   );
 
   @override
@@ -190,17 +175,11 @@ class CarpStudyAppState extends State<CarpStudyApp> {
 
     // Apply system overlay style after frame so Theme.of(context) is ready
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-      ));
+      SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(statusBarColor: Colors.transparent));
     });
     return MaterialApp.router(
       scaffoldMessengerKey: bloc.scaffoldKey,
-      supportedLocales: const [
-        Locale('en'),
-        Locale('da'),
-        Locale('es'),
-      ],
+      supportedLocales: const [Locale('en'), Locale('da'), Locale('es')],
       localizationsDelegates: [
         // Research Package translations
         rpLocalizationsDelegate,
@@ -222,11 +201,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
       },
       locale: bloc.localization?.locale,
       theme: carpTheme.copyWith(
-        extensions: [
-          carpTheme.extension<CarpColors>()!.copyWith(
-                primary: studyAppColors?.primary,
-              ),
-        ],
+        extensions: [carpTheme.extension<CarpColors>()!.copyWith(primary: studyAppColors?.primary)],
       ),
       darkTheme: carpDarkTheme,
       debugShowCheckedModeBanner: true,
@@ -240,8 +215,4 @@ FadeTransition bottomNavigationBarAnimation(
   Animation<double> animation,
   Animation<double> secondaryAnimation,
   Widget child,
-) =>
-    FadeTransition(
-      opacity: animation,
-      child: child,
-    );
+) => FadeTransition(opacity: animation, child: child);

--- a/lib/data/carp_backend.dart
+++ b/lib/data/carp_backend.dart
@@ -28,24 +28,13 @@ class CarpBackend {
   }
 
   /// The URI of the CAWS server - depending on deployment mode.
-  Uri get uri => Uri(
-        scheme: 'https',
-        host: uris[bloc.deploymentMode],
-      );
+  Uri get uri => Uri(scheme: 'https', host: uris[bloc.deploymentMode]);
 
   /// The URI of the CAWS authentication service.
   ///
   /// Of the form:
   ///    https://dev.carp.dk/auth/realms/Carp/
-  Uri get authUri => Uri(
-        scheme: 'https',
-        host: uris[bloc.deploymentMode],
-        pathSegments: [
-          'auth',
-          'realms',
-          'Carp',
-        ],
-      );
+  Uri get authUri => Uri(scheme: 'https', host: uris[bloc.deploymentMode], pathSegments: ['auth', 'realms', 'Carp']);
 
   /// The CAWS app configuration.
   late final CarpApp _app = CarpApp(name: "CAWS @ DTU", uri: uri);
@@ -54,17 +43,13 @@ class CarpBackend {
 
   /// The authentication configuration
   CarpAuthProperties get authProperties => CarpAuthProperties(
-        authURL: uri,
-        clientId: 'studies-app',
-        redirectURI: Uri.parse('carp-studies-auth://auth'),
-        anonymousRedirectURI: Uri.parse('carp-studies:/anonymous'),
-        // For authentication at CAWS the path is '/auth/realms/Carp'
-        discoveryURL: uri.replace(pathSegments: [
-          'auth',
-          'realms',
-          'Carp',
-        ]),
-      );
+    authURL: uri,
+    clientId: 'studies-app',
+    redirectURI: Uri.parse('carp-studies-auth://auth'),
+    anonymousRedirectURI: Uri.parse('carp-studies:/anonymous'),
+    // For authentication at CAWS the path is '/auth/realms/Carp'
+    discoveryURL: uri.replace(pathSegments: ['auth', 'realms', 'Carp']),
+  );
 
   /// Initialize this backend. Must be called before used.
   Future<void> initialize() async {
@@ -168,7 +153,8 @@ class CarpBackend {
     // (i.e. the invitation is for a smartphone).
     // This is done to avoid showing invitations for other devices (e.g. [WebBrowser]).
     invitations.removeWhere(
-        (invitation) => invitation.assignedDevices?.any((device) => device.device is! Smartphone) ?? false);
+      (invitation) => invitation.assignedDevices?.any((device) => device.device is! Smartphone) ?? false,
+    );
 
     return invitations;
   }
@@ -187,9 +173,7 @@ class CarpBackend {
   ///
   /// Looks for the first instance of a [RPConsentSignatureResult] in [consent]
   /// and uploads this.
-  Future<InformedConsentInput?> uploadInformedConsent(
-    RPTaskResult consent,
-  ) async {
+  Future<InformedConsentInput?> uploadInformedConsent(RPTaskResult consent) async {
     if (user == null) {
       warning('$runtimeType - No user authenticated.');
       return null;
@@ -201,9 +185,8 @@ class CarpBackend {
 
     late RPConsentSignatureResult signedConsent;
     try {
-      signedConsent = consent.results.values.firstWhere(
-        (result) => result is RPConsentSignatureResult,
-      ) as RPConsentSignatureResult;
+      signedConsent =
+          consent.results.values.firstWhere((result) => result is RPConsentSignatureResult) as RPConsentSignatureResult;
     } catch (_) {
       warning('$runtimeType - No signed informed consent found to be uploaded.');
       return null;
@@ -222,8 +205,10 @@ class CarpBackend {
     try {
       await CarpParticipationService().participation().setInformedConsent(uploadedConsent);
 
-      info('$runtimeType - Informed consent document uploaded successfully for '
-          'deployment id: ${bloc.study?.studyDeploymentId}');
+      info(
+        '$runtimeType - Informed consent document uploaded successfully for '
+        'deployment id: ${bloc.study?.studyDeploymentId}',
+      );
     } on Exception {
       warning('$runtimeType - Informed consent upload failed for username: $username');
     }

--- a/lib/data/local_participation_service.dart
+++ b/lib/data/local_participation_service.dart
@@ -11,23 +11,19 @@ class LocalParticipationService implements ParticipationService {
   factory LocalParticipationService() => _instance;
 
   @override
-  Future<List<ActiveParticipationInvitation>> getActiveParticipationInvitations([String? accountId]) async => [];
+  Future<List<ActiveParticipationInvitation>> getActiveParticipationInvitations({String? accountId}) async => [];
 
   @override
   Future<ParticipantData> getParticipantData(String studyDeploymentId) async =>
       ParticipantData(studyDeploymentId: studyDeploymentId);
 
   @override
-  Future<List<ParticipantData>> getParticipantDataList(
-    List<String> studyDeploymentIds,
-  ) async =>
-      [];
+  Future<List<ParticipantData>> getParticipantDataList(List<String> studyDeploymentIds) async => [];
 
   @override
   Future<ParticipantData> setParticipantData(
     String studyDeploymentId,
     Map<String, Data> data, [
     String? inputByParticipantRole,
-  ]) async =>
-      ParticipantData(studyDeploymentId: studyDeploymentId);
+  ]) async => ParticipantData(studyDeploymentId: studyDeploymentId);
 }

--- a/lib/data/local_resource_manager.dart
+++ b/lib/data/local_resource_manager.dart
@@ -42,28 +42,30 @@ class LocalResourceManager
   RPOrderedTask? get informedConsent => _informedConsent;
 
   @override
-  Future<RPOrderedTask?> getInformedConsent({bool refresh = false}) async {
+  Future<RPOrderedTask?> getConsentDocument({bool refresh = false}) async {
     if (_informedConsent == null) {
       try {
         var jsonString = await rootBundle.loadString('$basePath/resources/consent.json');
         Map<String, dynamic> jsonMap = json.decode(jsonString) as Map<String, dynamic>;
         _informedConsent = RPOrderedTask.fromJson(jsonMap);
       } catch (error) {
-        warning("$runtimeType - Could not load a local informed consent. "
-            "It should be added as an asset resource in 'carp/resources/consent.json'. $error");
+        warning(
+          "$runtimeType - Could not load a local informed consent. "
+          "It should be added as an asset resource in 'carp/resources/consent.json'. $error",
+        );
       }
     }
     return _informedConsent;
   }
 
   @override
-  Future<bool> setInformedConsent(RPOrderedTask informedConsent) async {
+  Future<bool> setConsentDocument(RPOrderedTask informedConsent) async {
     _informedConsent = informedConsent;
     return true;
   }
 
   @override
-  Future<bool> deleteInformedConsent() async {
+  Future<bool> deleteConsentDocument() async {
     _informedConsent = null;
     return true;
   }
@@ -71,10 +73,7 @@ class LocalResourceManager
   // LOCALIZATION
 
   @override
-  Future<Map<String, String>> getLocalizations(
-    Locale locale, {
-    bool refresh = false,
-  }) async {
+  Future<Map<String, String>> getLocalizations(Locale locale, {bool refresh = false}) async {
     if (_translations == null) {
       var path = '$basePath/lang/${locale.languageCode}.json';
       var jsonString = await rootBundle.loadString(path);
@@ -86,10 +85,7 @@ class LocalResourceManager
   }
 
   @override
-  Future<bool> setLocalizations(
-    Locale locale,
-    Map<String, dynamic> localizations,
-  ) {
+  Future<bool> setLocalizations(Locale locale, Map<String, dynamic> localizations) {
     throw UnimplementedError();
   }
 
@@ -104,11 +100,7 @@ class LocalResourceManager
   // MESSAGES
 
   @override
-  Future<List<Message>> getMessages({
-    DateTime? start,
-    DateTime? end,
-    int? count = 20,
-  }) async {
+  Future<List<Message>> getMessages({DateTime? start, DateTime? end, int? count = 20}) async {
     if (_messages.isEmpty) {
       final assetManifest = await AssetManifest.loadFromAssetBundle(rootBundle);
       final files = assetManifest.listAssets().where((string) => string.startsWith("$basePath/messages/")).toList();
@@ -152,17 +144,20 @@ class LocalResourceManager
           if (!(_protocol!.dataEndPoint!.type == DataEndPointTypes.FILE ||
               _protocol!.dataEndPoint!.type == DataEndPointTypes.SQLITE)) {
             warning(
-                "$runtimeType - Local protocol is trying to use a non-local data endpoint of type: '${_protocol!.dataEndPoint!.type}'. "
-                "This will not work. Replacing this data endpoint to use a local SQLite backend instead. "
-                "You can also change this in the local protocol stored in the 'carp/resources/protocol.json' file.");
+              "$runtimeType - Local protocol is trying to use a non-local data endpoint of type: '${_protocol!.dataEndPoint!.type}'. "
+              "This will not work. Replacing this data endpoint to use a local SQLite backend instead. "
+              "You can also change this in the local protocol stored in the 'carp/resources/protocol.json' file.",
+            );
 
             _protocol!.dataEndPoint = SQLiteDataEndPoint();
           }
         }
       } catch (error) {
-        warning("$runtimeType - Could not load a local study protocol. "
-            "It should be added as an asset resource in 'carp/resources/protocol.json'.\n"
-            "Error: $error");
+        warning(
+          "$runtimeType - Could not load a local study protocol. "
+          "It should be added as an asset resource in 'carp/resources/protocol.json'.\n"
+          "Error: $error",
+        );
       }
     }
     return _protocol;

--- a/lib/data/local_settings.dart
+++ b/lib/data/local_settings.dart
@@ -80,30 +80,26 @@ class LocalSettings {
   SmartphoneStudy? get study {
     if (_study != null) return _study;
     var jsonString = Settings().preferences?.getString(studyKey);
-    return _study =
-        (jsonString == null) ? null : _$SmartphoneStudyFromJson(json.decode(jsonString) as Map<String, dynamic>);
+    return _study = (jsonString == null)
+        ? null
+        : _$SmartphoneStudyFromJson(json.decode(jsonString) as Map<String, dynamic>);
   }
 
   set study(SmartphoneStudy? study) {
     assert(
-        study != null,
-        'Cannot set the study to null in Settings. '
-        "Use the 'eraseStudyDeployment()' method to erase study deployment information.");
+      study != null,
+      'Cannot set the study to null in Settings. '
+      "Use the 'eraseStudyDeployment()' method to erase study deployment information.",
+    );
     _study = study;
-    Settings().preferences?.setString(
-          studyKey,
-          json.encode(_$SmartphoneStudyToJson(study!)),
-        );
+    Settings().preferences?.setString(studyKey, json.encode(_$SmartphoneStudyToJson(study!)));
   }
 
   bool get hasSeenBluetoothConnectionInstructions =>
       Settings().preferences?.getBool('hasSeenBluetoothConnectionInstructions') ?? false;
 
   set hasSeenBluetoothConnectionInstructions(bool seen) {
-    Settings().preferences?.setBool(
-          'hasSeenBluetoothConnectionInstructions',
-          seen,
-        );
+    Settings().preferences?.setBool('hasSeenBluetoothConnectionInstructions', seen);
   }
 
   bool get isAnonymous => Settings().preferences!.getBool('isAnonymous') ?? false;
@@ -138,17 +134,17 @@ class LocalSettings {
 
 // Need to create our own JSON serializers here, since SmartphoneStudy is not made serializable
 Map<String, dynamic> _$SmartphoneStudyToJson(SmartphoneStudy study) => <String, dynamic>{
-      'studyId': study.studyId,
-      'studyDeploymentId': study.studyDeploymentId,
-      'deviceRoleName': study.deviceRoleName,
-      'participantId': study.participantId,
-      'participantRoleName': study.participantRoleName,
-    };
+  'studyId': study.studyId,
+  'studyDeploymentId': study.studyDeploymentId,
+  'deviceRoleName': study.deviceRoleName,
+  'participantId': study.participantId,
+  'participantRoleName': study.participantRoleName,
+};
 
 SmartphoneStudy _$SmartphoneStudyFromJson(Map<String, dynamic> json) => SmartphoneStudy(
-      studyId: json['studyId'] as String?,
-      studyDeploymentId: json['studyDeploymentId'] as String,
-      deviceRoleName: json['deviceRoleName'] as String,
-      participantId: json['participantId'] as String?,
-      participantRoleName: json['participantRoleName'] as String?,
-    );
+  studyId: json['studyId'] as String?,
+  studyDeploymentId: json['studyDeploymentId'] as String,
+  deviceRoleName: json['deviceRoleName'] as String,
+  participantId: json['participantId'] as String?,
+  participantRoleName: json['participantRoleName'] as String?,
+);

--- a/lib/data/participant.dart
+++ b/lib/data/participant.dart
@@ -22,15 +22,14 @@ class Participant {
     this.hasInformedConsentBeenAccepted = false,
   });
 
-  Participant.fromParticipationInvitation(
-    ActiveParticipationInvitation invitation,
-  ) : this(
-          studyId: invitation.studyId,
-          studyDeploymentId: invitation.studyDeploymentId,
-          deviceRoleName: invitation.assignedDevices?.first.device.roleName,
-          participantId: invitation.participation.participantId,
-          participantRoleName: invitation.participation.assignedRoles.roleNames?.first,
-        );
+  Participant.fromParticipationInvitation(ActiveParticipationInvitation invitation)
+    : this(
+        studyId: invitation.studyId,
+        studyDeploymentId: invitation.studyDeploymentId,
+        deviceRoleName: invitation.assignedDevices?.first.device.roleName,
+        participantId: invitation.participation.participantId,
+        participantRoleName: invitation.participation.assignedRoles.roleNames?.first,
+      );
 
   factory Participant.fromJson(Map<String, dynamic> json) => _$ParticipantFromJson(json);
   Map<String, dynamic> toJson() => _$ParticipantToJson(this);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,7 +39,8 @@ import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart' as qr;
 
 // the CARP packages
 import 'package:carp_serializable/carp_serializable.dart';
-import 'package:carp_core/carp_core.dart';
+// Both carp_core and carp_mobile_sensing export `Smartphone`; hide carp_core's.
+import 'package:carp_core/carp_core.dart' hide Smartphone;
 import 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
 import 'package:carp_audio_package/media.dart';
 //import 'package:carp_connectivity_package/connectivity.dart';

--- a/lib/main.g.dart
+++ b/lib/main.g.dart
@@ -7,36 +7,37 @@ part of 'main.dart';
 // **************************************************************************
 
 Participant _$ParticipantFromJson(Map<String, dynamic> json) => Participant(
-      studyId: json['studyId'] as String?,
-      studyDeploymentId: json['studyDeploymentId'] as String?,
-      deviceRoleName: json['deviceRoleName'] as String?,
-      participantId: json['participantId'] as String?,
-      participantRoleName: json['participantRoleName'] as String?,
-      hasInformedConsentBeenAccepted: json['hasInformedConsentBeenAccepted'] as bool? ?? false,
-    );
+  studyId: json['studyId'] as String?,
+  studyDeploymentId: json['studyDeploymentId'] as String?,
+  deviceRoleName: json['deviceRoleName'] as String?,
+  participantId: json['participantId'] as String?,
+  participantRoleName: json['participantRoleName'] as String?,
+  hasInformedConsentBeenAccepted: json['hasInformedConsentBeenAccepted'] as bool? ?? false,
+);
 
 Map<String, dynamic> _$ParticipantToJson(Participant instance) => <String, dynamic>{
-      if (instance.studyId case final value?) 'studyId': value,
-      if (instance.studyDeploymentId case final value?) 'studyDeploymentId': value,
-      if (instance.deviceRoleName case final value?) 'deviceRoleName': value,
-      if (instance.participantId case final value?) 'participantId': value,
-      if (instance.participantRoleName case final value?) 'participantRoleName': value,
-      'hasInformedConsentBeenAccepted': instance.hasInformedConsentBeenAccepted,
-    };
+  'studyId': ?instance.studyId,
+  'studyDeploymentId': ?instance.studyDeploymentId,
+  'deviceRoleName': ?instance.deviceRoleName,
+  'participantId': ?instance.participantId,
+  'participantRoleName': ?instance.participantRoleName,
+  'hasInformedConsentBeenAccepted': instance.hasInformedConsentBeenAccepted,
+};
 
-WeeklyActivities _$WeeklyActivitiesFromJson(Map<String, dynamic> json) => WeeklyActivities()
-  ..activities = (json['activities'] as Map<String, dynamic>).map(
-    (k, e) => MapEntry(
-        $enumDecode(_$ActivityTypeEnumMap, k),
-        (e as Map<String, dynamic>).map(
-          (k, e) => MapEntry(int.parse(k), (e as num).toInt()),
-        )),
-  );
+WeeklyActivities _$WeeklyActivitiesFromJson(Map<String, dynamic> json) =>
+    WeeklyActivities()
+      ..activities = (json['activities'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(
+          $enumDecode(_$ActivityTypeEnumMap, k),
+          (e as Map<String, dynamic>).map((k, e) => MapEntry(int.parse(k), (e as num).toInt())),
+        ),
+      );
 
 Map<String, dynamic> _$WeeklyActivitiesToJson(WeeklyActivities instance) => <String, dynamic>{
-      'activities': instance.activities
-          .map((k, e) => MapEntry(_$ActivityTypeEnumMap[k]!, e.map((k, e) => MapEntry(k.toString(), e)))),
-    };
+  'activities': instance.activities.map(
+    (k, e) => MapEntry(_$ActivityTypeEnumMap[k]!, e.map((k, e) => MapEntry(k.toString(), e))),
+  ),
+};
 
 const _$ActivityTypeEnumMap = {
   ActivityType.IN_VEHICLE: 'IN_VEHICLE',
@@ -53,22 +54,22 @@ WeeklyMobility _$WeeklyMobilityFromJson(Map<String, dynamic> json) => WeeklyMobi
   );
 
 Map<String, dynamic> _$WeeklyMobilityToJson(WeeklyMobility instance) => <String, dynamic>{
-      'weekMobility': instance.weekMobility.map((k, e) => MapEntry(k.toString(), e)),
-    };
+  'weekMobility': instance.weekMobility.map((k, e) => MapEntry(k.toString(), e)),
+};
 
 DailyMobility _$DailyMobilityFromJson(Map<String, dynamic> json) => DailyMobility(
-      (json['weekday'] as num).toInt(),
-      (json['places'] as num).toInt(),
-      (json['homeStay'] as num).toInt(),
-      (json['distance'] as num).toDouble(),
-    );
+  (json['weekday'] as num).toInt(),
+  (json['places'] as num).toInt(),
+  (json['homeStay'] as num).toInt(),
+  (json['distance'] as num).toDouble(),
+);
 
 Map<String, dynamic> _$DailyMobilityToJson(DailyMobility instance) => <String, dynamic>{
-      'weekday': instance.weekday,
-      'places': instance.places,
-      'homeStay': instance.homeStay,
-      'distance': instance.distance,
-    };
+  'weekday': instance.weekday,
+  'places': instance.places,
+  'homeStay': instance.homeStay,
+  'distance': instance.distance,
+};
 
 WeeklySteps _$WeeklyStepsFromJson(Map<String, dynamic> json) => WeeklySteps()
   ..weeklySteps = (json['weeklySteps'] as Map<String, dynamic>).map(
@@ -76,8 +77,8 @@ WeeklySteps _$WeeklyStepsFromJson(Map<String, dynamic> json) => WeeklySteps()
   );
 
 Map<String, dynamic> _$WeeklyStepsToJson(WeeklySteps instance) => <String, dynamic>{
-      'weeklySteps': instance.weeklySteps.map((k, e) => MapEntry(k.toString(), e)),
-    };
+  'weeklySteps': instance.weeklySteps.map((k, e) => MapEntry(k.toString(), e)),
+};
 
 HourlyHeartRate _$HourlyHeartRateFromJson(Map<String, dynamic> json) => HourlyHeartRate()
   ..hourlyHeartRate = (json['hourlyHeartRate'] as Map<String, dynamic>).map(
@@ -88,18 +89,16 @@ HourlyHeartRate _$HourlyHeartRateFromJson(Map<String, dynamic> json) => HourlyHe
   ..minHeartRate = (json['minHeartRate'] as num?)?.toDouble();
 
 Map<String, dynamic> _$HourlyHeartRateToJson(HourlyHeartRate instance) => <String, dynamic>{
-      'hourlyHeartRate': instance.hourlyHeartRate.map((k, e) => MapEntry(k.toString(), e)),
-      'lastUpdated': instance.lastUpdated.toIso8601String(),
-      if (instance.maxHeartRate case final value?) 'maxHeartRate': value,
-      if (instance.minHeartRate case final value?) 'minHeartRate': value,
-    };
+  'hourlyHeartRate': instance.hourlyHeartRate.map((k, e) => MapEntry(k.toString(), e)),
+  'lastUpdated': instance.lastUpdated.toIso8601String(),
+  'maxHeartRate': ?instance.maxHeartRate,
+  'minHeartRate': ?instance.minHeartRate,
+};
 
-HeartRateMinMaxPrHour _$HeartRateMinMaxPrHourFromJson(Map<String, dynamic> json) => HeartRateMinMaxPrHour(
-      (json['min'] as num?)?.toDouble(),
-      (json['max'] as num?)?.toDouble(),
-    );
+HeartRateMinMaxPrHour _$HeartRateMinMaxPrHourFromJson(Map<String, dynamic> json) =>
+    HeartRateMinMaxPrHour((json['min'] as num?)?.toDouble(), (json['max'] as num?)?.toDouble());
 
 Map<String, dynamic> _$HeartRateMinMaxPrHourToJson(HeartRateMinMaxPrHour instance) => <String, dynamic>{
-      if (instance.min case final value?) 'min': value,
-      if (instance.max case final value?) 'max': value,
-    };
+  'min': ?instance.min,
+  'max': ?instance.max,
+};

--- a/lib/ui/cards/activity_card.dart
+++ b/lib/ui/cards/activity_card.dart
@@ -19,8 +19,11 @@ class ActivityCardState extends State<ActivityCard> {
 
   final betweenSpace = 2.4;
 
-  List<List<int>> activitiesList =
-      List.generate(7, (_) => List.generate(4, (index) => index, growable: false), growable: false);
+  List<List<int>> activitiesList = List.generate(
+    7,
+    (_) => List.generate(4, (index) => index, growable: false),
+    growable: false,
+  );
 
   @override
   void initState() {
@@ -66,17 +69,13 @@ class ActivityCardState extends State<ActivityCard> {
               children: [
                 Text(
                   '${_walk! + _run! + _cycle!}',
-                  style: fs28fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey900!,
-                  ),
+                  style: fs28fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900!),
                 ),
                 Padding(
                   padding: const EdgeInsets.only(left: 4.0),
                   child: Text(
                     '${locale.translate('cards.activity.total.min')} ${_getDayName(touchedIndex)}',
-                    style: fs12fw700.copyWith(
-                      color: Theme.of(context).extension<CarpColors>()!.grey600,
-                    ),
+                    style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                   ),
                 ),
               ],
@@ -85,9 +84,7 @@ class ActivityCardState extends State<ActivityCard> {
               children: [
                 Text(
                   "${widget.model.currentMonth} ${widget.model.startOfWeek} - ${int.parse(widget.model.endOfWeek) < int.parse(widget.model.startOfWeek) ? widget.model.nextMonth : widget.model.currentMonth} ${widget.model.endOfWeek}, ${widget.model.currentYear}",
-                  style: fs12fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey600,
-                  ),
+                  style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                 ),
                 Spacer(),
               ],
@@ -109,12 +106,7 @@ class ActivityCardState extends State<ActivityCard> {
                     Expanded(
                       child: Row(
                         children: [
-                          Text(
-                            '$_walk',
-                            style: fs22fw700.copyWith(
-                              color: widget.colors[0],
-                            ),
-                          ),
+                          Text('$_walk', style: fs22fw700.copyWith(color: widget.colors[0])),
                           Padding(
                             padding: const EdgeInsets.all(4.0),
                             child: Text(
@@ -130,12 +122,7 @@ class ActivityCardState extends State<ActivityCard> {
                         children: [
                           Padding(
                             padding: const EdgeInsets.only(left: 8.0),
-                            child: Text(
-                              '$_run',
-                              style: fs12fw700.copyWith(
-                                color: widget.colors[1],
-                              ),
-                            ),
+                            child: Text('$_run', style: fs12fw700.copyWith(color: widget.colors[1])),
                           ),
                           Padding(
                             padding: const EdgeInsets.all(4.0),
@@ -146,24 +133,17 @@ class ActivityCardState extends State<ActivityCard> {
                           ),
                         ],
                       ),
-                    )
+                    ),
                   ],
                 ),
                 Row(
                   children: [
-                    Text(
-                      '$_cycle',
-                      style: fs22fw700.copyWith(
-                        color: widget.colors[2],
-                      ),
-                    ),
+                    Text('$_cycle', style: fs22fw700.copyWith(color: widget.colors[2])),
                     Padding(
                       padding: const EdgeInsets.only(left: 4.0),
                       child: Text(
                         locale.translate('cards.activity.cycling'),
-                        style: fs12fw700.copyWith(
-                          color: Theme.of(context).extension<CarpColors>()!.grey800,
-                        ),
+                        style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey800),
                       ),
                     ),
                   ],
@@ -182,19 +162,11 @@ class ActivityCardState extends State<ActivityCard> {
         alignment: BarChartAlignment.spaceAround,
         titlesData: FlTitlesData(
           bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              getTitlesWidget: bottomTitles,
-              reservedSize: 20,
-            ),
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: bottomTitles, reservedSize: 20),
           ),
           leftTitles: const AxisTitles(),
           rightTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              getTitlesWidget: rightTitles,
-              reservedSize: 48,
-            ),
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: rightTitles, reservedSize: 48),
           ),
           topTitles: const AxisTitles(),
         ),
@@ -214,29 +186,15 @@ class ActivityCardState extends State<ActivityCard> {
           drawVerticalLine: false,
           drawHorizontalLine: true,
           getDrawingHorizontalLine: (value) {
-            return FlLine(
-              color: Colors.grey.withValues(alpha: 0.3),
-              strokeWidth: 1,
-            );
+            return FlLine(color: Colors.grey.withValues(alpha: 0.3), strokeWidth: 1);
           },
         ),
-        borderData: FlBorderData(
-          show: true,
-          border: Border.all(
-            width: 1,
-            color: Colors.grey.withValues(alpha: 0.2),
-          ),
-        ),
+        borderData: FlBorderData(show: true, border: Border.all(width: 1, color: Colors.grey.withValues(alpha: 0.2))),
       ),
     );
   }
 
-  BarChartGroupData generateGroupData(
-    int x,
-    num walking,
-    num running,
-    num cycling,
-  ) {
+  BarChartGroupData generateGroupData(int x, num walking, num running, num cycling) {
     double roundness = 2;
     bool isTouched = touchedIndex == x;
     maxValue = max(maxValue, walking + running + cycling);
@@ -251,17 +209,19 @@ class ActivityCardState extends State<ActivityCard> {
       groupVertically: true,
       barRods: [
         BarChartRodData(
-            fromY: 0,
-            toY: walking + 0,
-            color: widget.colors[0].withValues(alpha: isTouched ? 0.8 : 1),
-            width: 32,
-            borderRadius: BorderRadius.all(Radius.circular(roundness))),
+          fromY: 0,
+          toY: walking + 0,
+          color: widget.colors[0].withValues(alpha: isTouched ? 0.8 : 1),
+          width: 32,
+          borderRadius: BorderRadius.all(Radius.circular(roundness)),
+        ),
         BarChartRodData(
-            fromY: walking + betweenSpace,
-            toY: walking + betweenSpace + running,
-            color: widget.colors[1].withValues(alpha: isTouched ? 0.8 : 1),
-            width: 32,
-            borderRadius: BorderRadius.all(Radius.circular(roundness))),
+          fromY: walking + betweenSpace,
+          toY: walking + betweenSpace + running,
+          color: widget.colors[1].withValues(alpha: isTouched ? 0.8 : 1),
+          width: 32,
+          borderRadius: BorderRadius.all(Radius.circular(roundness)),
+        ),
         BarChartRodData(
           fromY: walking + betweenSpace + running + betweenSpace,
           toY: walking + betweenSpace + running + betweenSpace + cycling,
@@ -284,9 +244,7 @@ class ActivityCardState extends State<ActivityCard> {
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
       ),
     );
   }

--- a/lib/ui/cards/anonymous_card.dart
+++ b/lib/ui/cards/anonymous_card.dart
@@ -11,13 +11,9 @@ class AnonymousCard extends StatelessWidget {
       color: Theme.of(context).extension<CarpColors>()!.grey50,
       elevation: 0,
       margin: const EdgeInsets.all(16.0),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(16.0),
-        ),
+        decoration: BoxDecoration(borderRadius: BorderRadius.circular(16.0)),
         child: Row(
           children: [
             Expanded(
@@ -32,10 +28,7 @@ class AnonymousCard extends StatelessWidget {
                           child: CircleAvatar(
                             radius: 18,
                             backgroundColor: CACHET.ANONYMOUS,
-                            child: Icon(
-                              Icons.info_outline,
-                              color: Colors.white,
-                            ),
+                            child: Icon(Icons.info_outline, color: Colors.white),
                           ),
                         ),
                         Padding(

--- a/lib/ui/cards/distance_card.dart
+++ b/lib/ui/cards/distance_card.dart
@@ -38,19 +38,12 @@ class _DistanceCardState extends State<DistanceCard> {
           children: [
             Row(
               children: [
-                Text(
-                  _distance,
-                  style: fs28fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey900!,
-                  ),
-                ),
+                Text(_distance, style: fs28fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900!)),
                 Padding(
                   padding: const EdgeInsets.only(left: 4.0),
                   child: Text(
                     'km ${_getDayName(touchedIndex)}',
-                    style: fs12fw700.copyWith(
-                      color: Theme.of(context).extension<CarpColors>()!.grey600,
-                    ),
+                    style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                   ),
                 ),
               ],
@@ -59,9 +52,7 @@ class _DistanceCardState extends State<DistanceCard> {
               children: [
                 Text(
                   "${widget.model.currentMonth} ${widget.model.startOfWeek} - ${int.parse(widget.model.endOfWeek) < int.parse(widget.model.startOfWeek) ? widget.model.nextMonth : widget.model.currentMonth} ${widget.model.endOfWeek}, ${widget.model.currentYear}",
-                  style: fs12fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey600,
-                  ),
+                  style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                 ),
                 Spacer(),
               ],
@@ -69,10 +60,7 @@ class _DistanceCardState extends State<DistanceCard> {
             SizedBox(
               height: 160,
               width: MediaQuery.of(context).size.width * 0.9,
-              child: StreamBuilder(
-                stream: widget.model.mobilityEvents,
-                builder: (context, snapshot) => barCharts,
-              ),
+              child: StreamBuilder(stream: widget.model.mobilityEvents, builder: (context, snapshot) => barCharts),
             ),
           ],
         ),
@@ -81,56 +69,41 @@ class _DistanceCardState extends State<DistanceCard> {
   }
 
   BarChart get barCharts {
-    return BarChart(BarChartData(
-      alignment: BarChartAlignment.spaceAround,
-      titlesData: FlTitlesData(
-        bottomTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: bottomTitles,
-            reservedSize: 20,
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: bottomTitles, reservedSize: 20),
           ),
-        ),
-        leftTitles: const AxisTitles(),
-        rightTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: rightTitles,
-            reservedSize: 48,
+          leftTitles: const AxisTitles(),
+          rightTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: rightTitles, reservedSize: 48),
           ),
+          topTitles: const AxisTitles(),
         ),
-        topTitles: const AxisTitles(),
-      ),
-      barTouchData: BarTouchData(
-        enabled: false,
-        touchCallback: (p0, p1) {
-          setState(() {
-            touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
-          });
-        },
-      ),
-      groupsSpace: 4,
-      barGroups: barChartsGroups,
-      maxY: (maxValue) * 1.2,
-      gridData: FlGridData(
-        show: true,
-        drawVerticalLine: false,
-        drawHorizontalLine: true,
-        getDrawingHorizontalLine: (value) {
-          return FlLine(
-            color: Colors.grey.withValues(alpha: 0.3),
-            strokeWidth: 1,
-          );
-        },
-      ),
-      borderData: FlBorderData(
-        show: true,
-        border: Border.all(
-          width: 1,
-          color: Colors.grey.withValues(alpha: 0.2),
+        barTouchData: BarTouchData(
+          enabled: false,
+          touchCallback: (p0, p1) {
+            setState(() {
+              touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
+            });
+          },
         ),
+        groupsSpace: 4,
+        barGroups: barChartsGroups,
+        maxY: (maxValue) * 1.2,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          drawHorizontalLine: true,
+          getDrawingHorizontalLine: (value) {
+            return FlLine(color: Colors.grey.withValues(alpha: 0.3), strokeWidth: 1);
+          },
+        ),
+        borderData: FlBorderData(show: true, border: Border.all(width: 1, color: Colors.grey.withValues(alpha: 0.2))),
       ),
-    ));
+    );
   }
 
   List<BarChartGroupData> get barChartsGroups {
@@ -151,10 +124,7 @@ class _DistanceCardState extends State<DistanceCard> {
           toY: step.toDouble(),
           color: widget.colors[0].withValues(alpha: isTouched ? 0.8 : 1),
           width: 32,
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(4),
-            topRight: Radius.circular(4),
-          ),
+          borderRadius: const BorderRadius.only(topLeft: Radius.circular(4), topRight: Radius.circular(4)),
         ),
       ],
     );
@@ -166,9 +136,7 @@ class _DistanceCardState extends State<DistanceCard> {
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
       ),
     );
   }

--- a/lib/ui/cards/heart_rate_card.dart
+++ b/lib/ui/cards/heart_rate_card.dart
@@ -22,13 +22,8 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
       duration: const Duration(seconds: 1),
       lowerBound: 0.9,
       upperBound: 1,
-    )..repeat(
-        reverse: true,
-      );
-    animation = CurvedAnimation(
-      parent: animationController,
-      curve: Curves.easeOut,
-    );
+    )..repeat(reverse: true);
+    animation = CurvedAnimation(parent: animationController, curve: Curves.easeOut);
   }
 
   @override
@@ -51,14 +46,8 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
                 return Column(
                   children: [
                     getDailyRange,
-                    SizedBox(
-                      height: 240,
-                      child: barCharts,
-                    ),
-                    SizedBox(
-                      height: 50,
-                      child: currentHeartRateWidget,
-                    )
+                    SizedBox(height: 240, child: barCharts),
+                    SizedBox(height: 50, child: currentHeartRateWidget),
                   ],
                 );
               },
@@ -80,19 +69,13 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
       children: [
         Container(
           margin: const EdgeInsets.only(left: 8, right: 4, bottom: 4),
-          child: Text(
-            min == null || max == null ? '-' : '${(min.toInt())} - ${(max.toInt())}',
-            style: fs28fw700,
-          ),
+          child: Text(min == null || max == null ? '-' : '${(min.toInt())} - ${(max.toInt())}', style: fs28fw700),
         ),
         Padding(
           padding: const EdgeInsets.only(bottom: 10),
           child: Text(
             min == null || max == null ? '' : locale.translate('cards.heartrate.bpm'),
-            style: fs10fw700.copyWith(
-              fontSize: 12,
-              color: Theme.of(context).extension<CarpColors>()!.grey600,
-            ),
+            style: fs10fw700.copyWith(fontSize: 12, color: Theme.of(context).extension<CarpColors>()!.grey600),
           ),
         ),
       ],
@@ -114,10 +97,7 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
               Container(
                 margin: const EdgeInsets.only(left: 8, bottom: 8, right: 4),
                 child: currentHeartRate != null
-                    ? Text(
-                        currentHeartRate.toStringAsFixed(0),
-                        style: fs28fw700,
-                      )
+                    ? Text(currentHeartRate.toStringAsFixed(0), style: fs28fw700)
                     : Text('-', style: fs28fw700),
               ),
               Padding(
@@ -129,18 +109,12 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
                     RepaintBoundary(
                       child: ScaleTransition(
                         scale: Tween<double>(begin: 1, end: 1).animate(animationController),
-                        child: Icon(
-                          Icons.favorite,
-                          color: CACHET.HEART_RATE_RED,
-                          size: 10,
-                        ),
+                        child: Icon(Icons.favorite, color: CACHET.HEART_RATE_RED, size: 10),
                       ),
                     ),
                     Text(
                       locale.translate('cards.heartrate.bpm'),
-                      style: fs10fw700.copyWith(
-                        color: Theme.of(context).extension<CarpColors>()!.grey600,
-                      ),
+                      style: fs10fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                     ),
                   ],
                 ),
@@ -177,10 +151,7 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
                   ),
                   TextSpan(
                     text: "\n${rod.fromY.toInt()}-${rod.toY.toInt()}",
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 30,
-                    ),
+                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 30),
                   ),
                   TextSpan(
                     text: "${locale.translate('cards.heartrate.bpm')}\n",
@@ -207,51 +178,31 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
         titlesData: FlTitlesData(
           show: true,
           bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              interval: 20,
-              getTitlesWidget: bottomTitles,
-            ),
+            sideTitles: SideTitles(showTitles: true, interval: 20, getTitlesWidget: bottomTitles),
           ),
           rightTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 48,
-              getTitlesWidget: rightTitles,
-            ),
+            sideTitles: SideTitles(showTitles: true, reservedSize: 48, getTitlesWidget: rightTitles),
           ),
-          topTitles: const AxisTitles(
-            sideTitles: SideTitles(showTitles: false),
-          ),
-          leftTitles: const AxisTitles(
-            sideTitles: SideTitles(showTitles: false),
-          ),
+          topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
         ),
         gridData: FlGridData(
-            show: true,
-            drawVerticalLine: true,
-            drawHorizontalLine: true,
-            getDrawingHorizontalLine: (value) => FlLine(
-                  color: Colors.grey.withValues(alpha: 0.2),
-                  strokeWidth: 1,
-                ),
-            checkToShowHorizontalLine: (value) => value % 100 == 0,
-            getDrawingVerticalLine: (value) =>
-                FlLine(color: Colors.grey.withValues(alpha: 0.2), strokeWidth: 1, dashArray: [3, 2]),
-            verticalInterval: 1 / 24,
-            checkToShowVerticalLine: (value) {
-              if ((value * 24).round() == 6) return true;
-              if ((value * 24).round() == 12) return true;
-              if ((value * 24).round() == 18) return true;
-              return false;
-            }),
-        borderData: FlBorderData(
           show: true,
-          border: Border.all(
-            width: 1,
-            color: Colors.grey.withValues(alpha: 0.2),
-          ),
+          drawVerticalLine: true,
+          drawHorizontalLine: true,
+          getDrawingHorizontalLine: (value) => FlLine(color: Colors.grey.withValues(alpha: 0.2), strokeWidth: 1),
+          checkToShowHorizontalLine: (value) => value % 100 == 0,
+          getDrawingVerticalLine: (value) =>
+              FlLine(color: Colors.grey.withValues(alpha: 0.2), strokeWidth: 1, dashArray: [3, 2]),
+          verticalInterval: 1 / 24,
+          checkToShowVerticalLine: (value) {
+            if ((value * 24).round() == 6) return true;
+            if ((value * 24).round() == 12) return true;
+            if ((value * 24).round() == 18) return true;
+            return false;
+          },
         ),
+        borderData: FlBorderData(show: true, border: Border.all(width: 1, color: Colors.grey.withValues(alpha: 0.2))),
         groupsSpace: 4,
         barGroups: getHeartRateBars(),
         minY: 0,
@@ -261,11 +212,7 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
   }
 
   Widget bottomTitles(double value, TitleMeta meta) {
-    final style = TextStyle(
-      color: Colors.grey.withValues(alpha: 0.6),
-      fontSize: 14,
-      fontWeight: FontWeight.bold,
-    );
+    final style = TextStyle(color: Colors.grey.withValues(alpha: 0.6), fontSize: 14, fontWeight: FontWeight.bold);
     String text;
     if (value == 0) {
       text = '00';
@@ -282,10 +229,7 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
     return SideTitleWidget(
       meta: meta,
       space: 0,
-      child: Text(
-        text,
-        style: style,
-      ),
+      child: Text(text, style: style),
     );
   }
 
@@ -295,26 +239,21 @@ class HeartRateCardWidgetState extends State<HeartRateCardWidget> with SingleTic
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
         maxLines: 1,
       ),
     );
   }
 
   List<BarChartGroupData> getHeartRateBars() => widget.model.hourlyHeartRate.entries
-      .map((value) => BarChartGroupData(
-            x: value.key,
-            barRods: [
-              BarChartRodData(
-                fromY: value.value.min,
-                toY: value.value.max ?? 0,
-                color: CACHET.HEART_RATE_RED,
-                width: 6,
-              ),
-            ],
-          ))
+      .map(
+        (value) => BarChartGroupData(
+          x: value.key,
+          barRods: [
+            BarChartRodData(fromY: value.value.min, toY: value.value.max ?? 0, color: CACHET.HEART_RATE_RED, width: 6),
+          ],
+        ),
+      )
       .toList();
 }
 

--- a/lib/ui/cards/media_card.dart
+++ b/lib/ui/cards/media_card.dart
@@ -47,16 +47,19 @@ class MediaCardWidgetState extends State<MediaCardWidget> {
                                         '${entry.value.tasksDone} ${locale.translate('cards.${entry.value.taskType}.title')}',
                                         style: fs16fw400ls1.copyWith(fontSize: 14),
                                       ),
-                                      LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
-                                        return HorizontalBar(
+                                      LayoutBuilder(
+                                        builder: (BuildContext context, BoxConstraints constraints) {
+                                          return HorizontalBar(
                                             parentWidth: constraints.maxWidth,
                                             names: entry.value.taskCount
                                                 .map((task) => locale.translate(task.title))
                                                 .toList(),
                                             values: entry.value.taskCount.map((task) => task.size).toList(),
                                             colors: CACHET.COLOR_LIST,
-                                            height: 18);
-                                      }),
+                                            height: 18,
+                                          );
+                                        },
+                                      ),
                                     ],
                                   ),
                                 )
@@ -68,7 +71,7 @@ class MediaCardWidgetState extends State<MediaCardWidget> {
                   ],
                 ),
               ],
-            )
+            ),
           ],
         ),
       ),

--- a/lib/ui/cards/mobility_card.dart
+++ b/lib/ui/cards/mobility_card.dart
@@ -35,19 +35,12 @@ class _MobilityCardState extends State<MobilityCard> {
           children: [
             Row(
               children: [
-                Text(
-                  '$_homestay%',
-                  style: fs28fw700.copyWith(
-                    color: widget.colors[0],
-                  ),
-                ),
+                Text('$_homestay%', style: fs28fw700.copyWith(color: widget.colors[0])),
                 Padding(
                   padding: const EdgeInsets.only(left: 4.0),
                   child: Text(
                     "${locale.translate('cards.mobility.homestay')} ${_getDayName(touchedIndex)}",
-                    style: fs12fw700.copyWith(
-                      color: Theme.of(context).extension<CarpColors>()!.grey900!,
-                    ),
+                    style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900!),
                   ),
                 ),
               ],
@@ -56,9 +49,7 @@ class _MobilityCardState extends State<MobilityCard> {
               children: [
                 Text(
                   "${widget.model.currentMonth} ${widget.model.startOfWeek} - ${int.parse(widget.model.endOfWeek) < int.parse(widget.model.startOfWeek) ? widget.model.nextMonth : widget.model.currentMonth} ${widget.model.endOfWeek}, ${widget.model.currentYear}",
-                  style: fs12fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey600,
-                  ),
+                  style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                 ),
                 Spacer(),
               ],
@@ -77,12 +68,7 @@ class _MobilityCardState extends State<MobilityCard> {
               children: [
                 Row(
                   children: [
-                    Text(
-                      '$_places',
-                      style: fs22fw700.copyWith(
-                        color: widget.colors[0],
-                      ),
-                    ),
+                    Text('$_places', style: fs22fw700.copyWith(color: widget.colors[0])),
                     Padding(
                       padding: const EdgeInsets.all(4.0),
                       child: Text(
@@ -101,56 +87,41 @@ class _MobilityCardState extends State<MobilityCard> {
   }
 
   BarChart get barCharts {
-    return BarChart(BarChartData(
-      alignment: BarChartAlignment.spaceAround,
-      titlesData: FlTitlesData(
-        bottomTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: bottomTitles,
-            reservedSize: 20,
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: bottomTitles, reservedSize: 20),
           ),
-        ),
-        leftTitles: const AxisTitles(),
-        rightTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: rightTitles,
-            reservedSize: 48,
+          leftTitles: const AxisTitles(),
+          rightTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: rightTitles, reservedSize: 48),
           ),
+          topTitles: const AxisTitles(),
         ),
-        topTitles: const AxisTitles(),
-      ),
-      barTouchData: BarTouchData(
-        enabled: false,
-        touchCallback: (p0, p1) {
-          setState(() {
-            touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
-          });
-        },
-      ),
-      groupsSpace: 4,
-      barGroups: barChartsGroups,
-      maxY: 100,
-      gridData: FlGridData(
-        show: true,
-        drawVerticalLine: false,
-        drawHorizontalLine: true,
-        getDrawingHorizontalLine: (value) {
-          return FlLine(
-            color: Colors.grey.withValues(alpha: 0.3),
-            strokeWidth: 1,
-          );
-        },
-      ),
-      borderData: FlBorderData(
-        show: true,
-        border: Border.all(
-          width: 1,
-          color: Colors.grey.withValues(alpha: 0.2),
+        barTouchData: BarTouchData(
+          enabled: false,
+          touchCallback: (p0, p1) {
+            setState(() {
+              touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
+            });
+          },
         ),
+        groupsSpace: 4,
+        barGroups: barChartsGroups,
+        maxY: 100,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          drawHorizontalLine: true,
+          getDrawingHorizontalLine: (value) {
+            return FlLine(color: Colors.grey.withValues(alpha: 0.3), strokeWidth: 1);
+          },
+        ),
+        borderData: FlBorderData(show: true, border: Border.all(width: 1, color: Colors.grey.withValues(alpha: 0.2))),
       ),
-    ));
+    );
   }
 
   List<BarChartGroupData> get barChartsGroups {
@@ -173,19 +144,13 @@ class _MobilityCardState extends State<MobilityCard> {
           toY: places.toDouble(),
           color: widget.colors[1].withValues(alpha: isTouched ? 0.8 : 1),
           width: 16,
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(4),
-            topRight: Radius.circular(4),
-          ),
+          borderRadius: const BorderRadius.only(topLeft: Radius.circular(4), topRight: Radius.circular(4)),
         ),
         BarChartRodData(
           toY: homestay.toDouble(),
           color: widget.colors[0].withValues(alpha: isTouched ? 0.8 : 1),
           width: 16,
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(4),
-            topRight: Radius.circular(4),
-          ),
+          borderRadius: const BorderRadius.only(topLeft: Radius.circular(4), topRight: Radius.circular(4)),
         ),
       ],
     );
@@ -197,9 +162,7 @@ class _MobilityCardState extends State<MobilityCard> {
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
       ),
     );
   }
@@ -210,9 +173,7 @@ class _MobilityCardState extends State<MobilityCard> {
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
       ),
     );
   }

--- a/lib/ui/cards/scoreboard_card.dart
+++ b/lib/ui/cards/scoreboard_card.dart
@@ -14,12 +14,7 @@ class ScoreboardCardState extends State<ScoreboardCard> {
 
     return SliverPersistentHeader(
       pinned: false,
-      delegate: ScoreboardPersistentHeaderDelegate(
-        model: widget.model,
-        locale: locale,
-        minExtent: 40,
-        maxExtent: 110,
-      ),
+      delegate: ScoreboardPersistentHeaderDelegate(model: widget.model, locale: locale, minExtent: 40, maxExtent: 110),
     );
   }
 }
@@ -51,38 +46,52 @@ class ScoreboardPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
     double offsetForShrink = 50;
 
     List<Widget> childrenDays = [
-      Text(model.daysInStudy.toString(),
-          style: fs36fw800.copyWith(
-              fontSize: calculateScrollAwareSizing(shrinkOffset, fs20fw800.fontSize!, fs36fw800.fontSize!),
-              color: Theme.of(context).extension<CarpColors>()!.grey900)),
+      Text(
+        model.daysInStudy.toString(),
+        style: fs36fw800.copyWith(
+          fontSize: calculateScrollAwareSizing(shrinkOffset, fs20fw800.fontSize!, fs36fw800.fontSize!),
+          color: Theme.of(context).extension<CarpColors>()!.grey900,
+        ),
+      ),
       if (shrinkOffset < offsetForShrink)
-        Text(locale.translate('cards.scoreboard.days'),
-            style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900)),
+        Text(
+          locale.translate('cards.scoreboard.days'),
+          style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
+        ),
       if (shrinkOffset > offsetForShrink)
         Padding(
           padding: const EdgeInsets.only(left: 8.0),
-          child: Text(locale.translate('cards.scoreboard.days-short'),
-              style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900)),
-        )
+          child: Text(
+            locale.translate('cards.scoreboard.days-short'),
+            style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
+          ),
+        ),
     ];
 
     List<Widget> childrenTasks = [
-      Text(model.taskCompleted.toString(),
-          style: fs36fw800.copyWith(
-              fontSize: calculateScrollAwareSizing(shrinkOffset, fs20fw800.fontSize!, fs36fw800.fontSize!),
-              color: Theme.of(context).extension<CarpColors>()!.primary)),
+      Text(
+        model.taskCompleted.toString(),
+        style: fs36fw800.copyWith(
+          fontSize: calculateScrollAwareSizing(shrinkOffset, fs20fw800.fontSize!, fs36fw800.fontSize!),
+          color: Theme.of(context).extension<CarpColors>()!.primary,
+        ),
+      ),
       if (shrinkOffset < offsetForShrink)
-        Text(locale.translate('cards.scoreboard.tasks'),
-            style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary)),
+        Text(
+          locale.translate('cards.scoreboard.tasks'),
+          style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary),
+        ),
       if (shrinkOffset > offsetForShrink)
         Expanded(
           flex: 0,
           child: Padding(
             padding: const EdgeInsets.only(left: 8.0),
-            child: Text(locale.translate('cards.scoreboard.tasks-short'),
-                style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary)),
+            child: Text(
+              locale.translate('cards.scoreboard.tasks-short'),
+              style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary),
+            ),
           ),
-        )
+        ),
     ];
 
     return Container(
@@ -100,14 +109,8 @@ class ScoreboardPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
             children: [
               Expanded(
                 child: shrinkOffset < offsetForShrink
-                    ? Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: childrenDays,
-                      )
-                    : Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: childrenDays,
-                      ),
+                    ? Column(mainAxisAlignment: MainAxisAlignment.center, children: childrenDays)
+                    : Row(mainAxisAlignment: MainAxisAlignment.center, children: childrenDays),
               ),
               // A vertical divider line with rounded corners that spans from 10% to 90% of the height
               Expanded(
@@ -123,15 +126,9 @@ class ScoreboardPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
               ),
               Expanded(
                 child: shrinkOffset < offsetForShrink
-                    ? Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: childrenTasks,
-                      )
-                    : Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: childrenTasks,
-                      ),
-              )
+                    ? Column(mainAxisAlignment: MainAxisAlignment.center, children: childrenTasks)
+                    : Row(mainAxisAlignment: MainAxisAlignment.center, children: childrenTasks),
+              ),
             ],
           );
         },
@@ -158,10 +155,8 @@ class ScoreboardPersistentHeaderDelegate extends SliverPersistentHeaderDelegate 
   }
 
   @override
-  FloatingHeaderSnapConfiguration get snapConfiguration => FloatingHeaderSnapConfiguration(
-        curve: Curves.linear,
-        duration: const Duration(milliseconds: 100),
-      );
+  FloatingHeaderSnapConfiguration get snapConfiguration =>
+      FloatingHeaderSnapConfiguration(curve: Curves.linear, duration: const Duration(milliseconds: 100));
 
   @override
   OverScrollHeaderStretchConfiguration get stretchConfiguration => OverScrollHeaderStretchConfiguration();

--- a/lib/ui/cards/steps_card.dart
+++ b/lib/ui/cards/steps_card.dart
@@ -36,17 +36,13 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
               children: [
                 Text(
                   _step > 0 ? '$_step' : '0',
-                  style: fs28fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey900!,
-                  ),
+                  style: fs28fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900!),
                 ),
                 Padding(
                   padding: const EdgeInsets.only(left: 4.0),
                   child: Text(
                     '${locale.translate('cards.steps.steps')} ${_getDayName(touchedIndex)}',
-                    style: fs12fw700.copyWith(
-                      color: Theme.of(context).extension<CarpColors>()!.grey600,
-                    ),
+                    style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                   ),
                 ),
               ],
@@ -55,9 +51,7 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
               children: [
                 Text(
                   "${widget.model.currentMonth} ${widget.model.startOfWeek} - ${int.parse(widget.model.endOfWeek) < int.parse(widget.model.startOfWeek) ? widget.model.nextMonth : widget.model.currentMonth} ${widget.model.endOfWeek}, ${widget.model.currentYear}",
-                  style: fs12fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey600,
-                  ),
+                  style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
                 ),
                 Spacer(),
               ],
@@ -79,56 +73,41 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
   }
 
   BarChart get barCharts {
-    return BarChart(BarChartData(
-      alignment: BarChartAlignment.spaceAround,
-      titlesData: FlTitlesData(
-        bottomTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: bottomTitles,
-            reservedSize: 20,
+    return BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceAround,
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: bottomTitles, reservedSize: 20),
           ),
-        ),
-        leftTitles: const AxisTitles(),
-        rightTitles: AxisTitles(
-          sideTitles: SideTitles(
-            showTitles: true,
-            getTitlesWidget: rightTitles,
-            reservedSize: 48,
+          leftTitles: const AxisTitles(),
+          rightTitles: AxisTitles(
+            sideTitles: SideTitles(showTitles: true, getTitlesWidget: rightTitles, reservedSize: 48),
           ),
+          topTitles: const AxisTitles(),
         ),
-        topTitles: const AxisTitles(),
-      ),
-      barTouchData: BarTouchData(
-        enabled: false,
-        touchCallback: (p0, p1) {
-          setState(() {
-            touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
-          });
-        },
-      ),
-      groupsSpace: 4,
-      barGroups: barChartsGroups,
-      maxY: (maxValue) * 1.2,
-      gridData: FlGridData(
-        show: true,
-        drawVerticalLine: false,
-        drawHorizontalLine: true,
-        getDrawingHorizontalLine: (value) {
-          return FlLine(
-            color: Colors.grey.withValues(alpha: 0.3),
-            strokeWidth: 1,
-          );
-        },
-      ),
-      borderData: FlBorderData(
-        show: true,
-        border: Border.all(
-          width: 1,
-          color: Colors.grey.withValues(alpha: 0.2),
+        barTouchData: BarTouchData(
+          enabled: false,
+          touchCallback: (p0, p1) {
+            setState(() {
+              touchedIndex = (p1?.spot?.touchedBarGroupIndex ?? DateTime.now().weekday - 1) + 1;
+            });
+          },
         ),
+        groupsSpace: 4,
+        barGroups: barChartsGroups,
+        maxY: (maxValue) * 1.2,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          drawHorizontalLine: true,
+          getDrawingHorizontalLine: (value) {
+            return FlLine(color: Colors.grey.withValues(alpha: 0.3), strokeWidth: 1);
+          },
+        ),
+        borderData: FlBorderData(show: true, border: Border.all(width: 1, color: Colors.grey.withValues(alpha: 0.2))),
       ),
-    ));
+    );
   }
 
   List<BarChartGroupData> get barChartsGroups {
@@ -149,10 +128,7 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
           toY: step.toDouble(),
           color: widget.colors[1].withValues(alpha: isTouched ? 0.8 : 1),
           width: 32,
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(4),
-            topRight: Radius.circular(4),
-          ),
+          borderRadius: const BorderRadius.only(topLeft: Radius.circular(4), topRight: Radius.circular(4)),
         ),
       ],
     );
@@ -164,9 +140,7 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
       space: 6,
       child: Text(
         value.toInt() % meta.appliedInterval == 0 ? value.toInt().toString() : '',
-        style: fs14ls1.copyWith(
-          color: Theme.of(context).extension<CarpColors>()!.grey600,
-        ),
+        style: fs14ls1.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
       ),
     );
   }
@@ -175,10 +149,7 @@ class StepsCardWidgetState extends State<StepsCardWidget> {
     const style = TextStyle(fontSize: 10);
     return SideTitleWidget(
       meta: meta,
-      child: Text(
-        _getDayName(value.toInt()),
-        style: style,
-      ),
+      child: Text(_getDayName(value.toInt()), style: style),
     );
   }
 

--- a/lib/ui/cards/study_progress_card.dart
+++ b/lib/ui/cards/study_progress_card.dart
@@ -4,8 +4,11 @@ class StudyProgressCardWidget extends StatefulWidget {
   final StudyProgressCardViewModel model;
 
   final List<Color> colors;
-  const StudyProgressCardWidget(this.model,
-      {super.key, this.colors = const [CACHET.BLUE_1, CACHET.RED_1, CACHET.GREY_6]});
+  const StudyProgressCardWidget(
+    this.model, {
+    super.key,
+    this.colors = const [CACHET.BLUE_1, CACHET.RED_1, CACHET.GREY_6],
+  });
 
   @override
   StudyProgressCardWidgetState createState() => StudyProgressCardWidgetState();
@@ -30,9 +33,7 @@ class StudyProgressCardWidgetState extends State<StudyProgressCardWidget> {
                   padding: const EdgeInsets.only(left: 8),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Text(locale.translate('cards.study_progress.title'), style: fs16fw400ls1),
-                    ],
+                    children: <Widget>[Text(locale.translate('cards.study_progress.title'), style: fs16fw400ls1)],
                   ),
                 ),
                 SizedBox(
@@ -154,13 +155,7 @@ class TaskProgressPainter extends CustomPainter {
       );
 
       // draw a full circle as a background with a faint color
-      canvas.drawArc(
-        Rect.fromCircle(center: center, radius: radius),
-        0,
-        2 * pi,
-        false,
-        paintBackground,
-      );
+      canvas.drawArc(Rect.fromCircle(center: center, radius: radius), 0, 2 * pi, false, paintBackground);
     }
   }
 

--- a/lib/ui/cards/survey_card.dart
+++ b/lib/ui/cards/survey_card.dart
@@ -34,13 +34,14 @@ class _SurveyCardState extends State<SurveyCard> {
             SizedBox(
               height: 160,
               width: MediaQuery.of(context).size.width * 0.9,
-              child: Row(children: [
-                // List of text with the number of surveys done for each survey
-                Expanded(
-                  flex: 2,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 8),
-                    child: Column(
+              child: Row(
+                children: [
+                  // List of text with the number of surveys done for each survey
+                  Expanded(
+                    flex: 2,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 8),
+                      child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: widget.model.tasksTable.entries.map((entry) {
                           Widget dot = Container(
@@ -55,38 +56,27 @@ class _SurveyCardState extends State<SurveyCard> {
                             '${entry.value} ${locale.translate(entry.key).truncateTo(12)}',
                             style: fs12fw400,
                           );
-                          return Row(
-                            children: [
-                              dot,
-                              const SizedBox(width: 8),
-                              text,
-                            ],
-                          );
-                        }).toList()),
-                  ),
-                ),
-                // The pie chart
-                Expanded(
-                  flex: 3,
-                  child: Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      PieChart(
-                        PieChartData(
-                          sections: pieChartSections,
-                          startDegreeOffset: 270,
-                        ),
+                          return Row(children: [dot, const SizedBox(width: 8), text]);
+                        }).toList(),
                       ),
-                      Text(
-                        '$totalSurveys',
-                        style: fs24fw700.copyWith(
-                          color: Theme.of(context).extension<CarpColors>()!.grey800,
-                        ),
-                      )
-                    ],
+                    ),
                   ),
-                ),
-              ]),
+                  // The pie chart
+                  Expanded(
+                    flex: 3,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        PieChart(PieChartData(sections: pieChartSections, startDegreeOffset: 270)),
+                        Text(
+                          '$totalSurveys',
+                          style: fs24fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey800),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),
@@ -95,16 +85,14 @@ class _SurveyCardState extends State<SurveyCard> {
   }
 
   List<PieChartSectionData> get pieChartSections {
-    return widget.model.tasksTable.entries.map(
-      (entry) {
-        return PieChartSectionData(
-          // Color should be the next color in the list
-          color: widget.colors[widget.model.tasksTable.keys.toList().indexOf(entry.key)],
-          value: entry.value.toDouble(),
-          title: '${entry.value}',
-          showTitle: false,
-        );
-      },
-    ).toList();
+    return widget.model.tasksTable.entries.map((entry) {
+      return PieChartSectionData(
+        // Color should be the next color in the list
+        color: widget.colors[widget.model.tasksTable.keys.toList().indexOf(entry.key)],
+        value: entry.value.toDouble(),
+        title: '${entry.value}',
+        showTitle: false,
+      );
+    }).toList();
   }
 }

--- a/lib/ui/carp_study_style.dart
+++ b/lib/ui/carp_study_style.dart
@@ -44,23 +44,24 @@ class StudyAppColors extends ThemeExtension<StudyAppColors> {
   final Color? grey950;
 
   @override
-  StudyAppColors copyWith(
-      {Color? primary,
-      Color? warningColor,
-      Color? backgroundGray,
-      Color? tabBarBackground,
-      Color? white,
-      Color? grey50,
-      Color? grey100,
-      Color? grey200,
-      Color? grey300,
-      Color? grey400,
-      Color? grey500,
-      Color? grey600,
-      Color? grey700,
-      Color? grey800,
-      Color? grey900,
-      Color? grey950}) {
+  StudyAppColors copyWith({
+    Color? primary,
+    Color? warningColor,
+    Color? backgroundGray,
+    Color? tabBarBackground,
+    Color? white,
+    Color? grey50,
+    Color? grey100,
+    Color? grey200,
+    Color? grey300,
+    Color? grey400,
+    Color? grey500,
+    Color? grey600,
+    Color? grey700,
+    Color? grey800,
+    Color? grey900,
+    Color? grey950,
+  }) {
     return StudyAppColors(
       primary: primary ?? this.primary,
       warningColor: warningColor ?? this.warningColor,
@@ -126,51 +127,39 @@ ThemeData carpStudyTheme = ThemeData.light().copyWith(
       grey800: const Color(0xff2C2C2E),
       grey900: const Color(0xff1C1C1E),
       grey950: const Color(0xff0E0E0E),
-    )
+    ),
   ],
   primaryColor: const Color(0xff006398),
   colorScheme: const ColorScheme.light().copyWith(
-      secondary: const Color(0xFFFAFAFA),
-      primary: const Color(0xFF206FA2),
-      tertiary: const ui.Color.fromARGB(255, 230, 230, 230)),
+    secondary: const Color(0xFFFAFAFA),
+    primary: const Color(0xFF206FA2),
+    tertiary: const ui.Color.fromARGB(255, 230, 230, 230),
+  ),
   //accentColor: Color(0xFFFAFAFA), //Color(0xffcce8fa),
   hoverColor: const Color(0xFFF1F9FF),
   scaffoldBackgroundColor: const Color(0xFFFFFFFF),
-  textTheme: ThemeData.light()
-      .textTheme
+  textTheme: ThemeData.light().textTheme
       .copyWith(
-        bodySmall: ThemeData.light().textTheme.bodySmall!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 14.0,
-            ),
-        bodyLarge: ThemeData.light().textTheme.bodyLarge!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 18.0,
-            ),
-        bodyMedium: ThemeData.light().textTheme.bodyMedium!.copyWith(
-              fontWeight: FontWeight.w400,
-              fontSize: 16.0,
-            ),
-        titleMedium: ThemeData.light()
-            .textTheme
-            .titleMedium!
-            .copyWith(fontWeight: FontWeight.w600, fontSize: 20.0, color: const Color(0xFF206FA2)),
-        titleLarge: ThemeData.light().textTheme.titleLarge!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 20.0,
-            ),
+        bodySmall: ThemeData.light().textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 14.0),
+        bodyLarge: ThemeData.light().textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0),
+        bodyMedium: ThemeData.light().textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 16.0),
+        titleMedium: ThemeData.light().textTheme.titleMedium!.copyWith(
+          fontWeight: FontWeight.w600,
+          fontSize: 20.0,
+          color: const Color(0xFF206FA2),
+        ),
+        titleLarge: ThemeData.light().textTheme.titleLarge!.copyWith(fontWeight: FontWeight.w500, fontSize: 20.0),
         headlineMedium: ThemeData.light().textTheme.headlineMedium!.copyWith(
-              fontWeight: FontWeight.w700,
-              fontSize: 30.0,
-            ),
-        labelLarge: ThemeData.light()
-            .textTheme
-            .labelLarge!
-            .copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Colors.white),
+          fontWeight: FontWeight.w700,
+          fontSize: 30.0,
+        ),
+        labelLarge: ThemeData.light().textTheme.labelLarge!.copyWith(
+          fontWeight: FontWeight.w500,
+          fontSize: 16.0,
+          color: Colors.white,
+        ),
       )
-      .apply(
-        fontFamily: 'OpenSans',
-      ),
+      .apply(fontFamily: 'OpenSans'),
   pageTransitionsTheme: const PageTransitionsTheme(
     builders: <TargetPlatform, PageTransitionsBuilder>{
       TargetPlatform.android: CupertinoPageTransitionsBuilder(),
@@ -198,7 +187,7 @@ ThemeData carpStudyDarkTheme = ThemeData.dark().copyWith(
       grey800: const Color(0xffF2F2F7),
       grey900: const Color(0xffF2F2F7),
       grey950: const Color(0xff0E0E0E),
-    )
+    ),
   ],
   primaryColor: const Color(0xff0379ff),
   colorScheme: const ColorScheme.dark().copyWith(
@@ -208,38 +197,26 @@ ThemeData carpStudyDarkTheme = ThemeData.dark().copyWith(
   ),
   // accentColor: Color(0xff4C4C4C),
   disabledColor: const Color(0xffcce8fa),
-  textTheme: ThemeData.dark()
-      .textTheme
+  textTheme: ThemeData.dark().textTheme
       .copyWith(
-        bodySmall: ThemeData.dark().textTheme.bodySmall!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 14.0,
-            ),
-        bodyLarge: ThemeData.dark().textTheme.bodyLarge!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 18.0,
-            ),
-        bodyMedium: ThemeData.dark().textTheme.bodyMedium!.copyWith(
-              fontWeight: FontWeight.w400,
-              fontSize: 16.0,
-            ),
+        bodySmall: ThemeData.dark().textTheme.bodySmall!.copyWith(fontWeight: FontWeight.w500, fontSize: 14.0),
+        bodyLarge: ThemeData.dark().textTheme.bodyLarge!.copyWith(fontWeight: FontWeight.w500, fontSize: 18.0),
+        bodyMedium: ThemeData.dark().textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.w400, fontSize: 16.0),
         titleMedium: ThemeData.dark().textTheme.titleMedium!.copyWith(
-              fontWeight: FontWeight.w600,
-              fontSize: 20.0,
-              color: const Color(0xff81C7F3),
-            ),
-        titleLarge: ThemeData.dark().textTheme.titleLarge!.copyWith(
-              fontWeight: FontWeight.w500,
-              fontSize: 20.0,
-            ),
+          fontWeight: FontWeight.w600,
+          fontSize: 20.0,
+          color: const Color(0xff81C7F3),
+        ),
+        titleLarge: ThemeData.dark().textTheme.titleLarge!.copyWith(fontWeight: FontWeight.w500, fontSize: 20.0),
         headlineMedium: ThemeData.dark().textTheme.headlineMedium!.copyWith(
-              fontWeight: FontWeight.w700,
-              fontSize: 30.0,
-            ),
-        labelLarge: ThemeData.dark()
-            .textTheme
-            .labelLarge!
-            .copyWith(fontWeight: FontWeight.w500, fontSize: 16.0, color: Colors.grey.shade800),
+          fontWeight: FontWeight.w700,
+          fontSize: 30.0,
+        ),
+        labelLarge: ThemeData.dark().textTheme.labelLarge!.copyWith(
+          fontWeight: FontWeight.w500,
+          fontSize: 16.0,
+          color: Colors.grey.shade800,
+        ),
       )
       .apply(
         fontFamily: 'OpenSans',

--- a/lib/ui/helpers.dart
+++ b/lib/ui/helpers.dart
@@ -7,8 +7,8 @@ part of carp_study_app;
 extension MessageTypeUI on MessageType {
   /// The icon representing this message type.
   IconData get icon => switch (this) {
-        MessageType.announcement => Icons.campaign,
-        MessageType.news => Icons.newspaper,
-        MessageType.article => Icons.article,
-      };
+    MessageType.announcement => Icons.campaign,
+    MessageType.news => Icons.newspaper,
+    MessageType.article => Icons.article,
+  };
 }

--- a/lib/ui/pages/data_visualization_page.dart
+++ b/lib/ui/pages/data_visualization_page.dart
@@ -15,9 +15,9 @@ class _DataVisualizationPageState extends State<DataVisualizationPage> {
   Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
     return Scaffold(
-        backgroundColor: Theme.of(context).extension<CarpColors>()!.backgroundGray,
-        body: SafeArea(
-            child: Column(
+      backgroundColor: Theme.of(context).extension<CarpColors>()!.backgroundGray,
+      body: SafeArea(
+        child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
@@ -35,11 +35,13 @@ class _DataVisualizationPageState extends State<DataVisualizationPage> {
                     mainAxisAlignment: MainAxisAlignment.start,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(locale.translate('pages.data_viz.title'),
-                          style: fs24fw700.copyWith(
-                            color: Theme.of(context).extension<CarpColors>()!.grey900,
-                            fontWeight: FontWeight.bold,
-                          )),
+                      Text(
+                        locale.translate('pages.data_viz.title'),
+                        style: fs24fw700.copyWith(
+                          color: Theme.of(context).extension<CarpColors>()!.grey900,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -54,18 +56,20 @@ class _DataVisualizationPageState extends State<DataVisualizationPage> {
                   children: [
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 24.0),
-                      child: Text(locale.translate('pages.data_viz.thanks'),
-                          style: fs16fw600.copyWith(
-                            color: Theme.of(context).extension<CarpColors>()!.grey600,
-                          )),
+                      child: Text(
+                        locale.translate('pages.data_viz.thanks'),
+                        style: fs16fw600.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
+                      ),
                     ),
                     ..._dataVizCards,
                   ],
                 ),
               ),
-            )
+            ),
           ],
-        )));
+        ),
+      ),
+    );
   }
 
   // The list of cards, depending on what measures are defined in the study.
@@ -103,7 +107,7 @@ class _DataVisualizationPageState extends State<DataVisualizationPage> {
       widgets.add(MediaCardWidget(mediaModelsList));
     }
 
-    if (bloc.hasMeasure(SensorSamplingPackage.STEP_COUNT)) {
+    if (bloc.hasMeasure(CarpDataTypes.STEP_COUNT)) {
       widgets.add(StepsCardWidget(widget.model.stepsCardDataModel));
     }
     if (bloc.hasMeasure(ContextSamplingPackage.ACTIVITY)) {

--- a/lib/ui/pages/device_list_page.dart
+++ b/lib/ui/pages/device_list_page.dart
@@ -16,16 +16,20 @@ class DeviceListPageState extends State<DeviceListPage> {
   StreamSubscription<BluetoothAdapterState>? bluetoothStateStream;
   BluetoothAdapterState? bluetoothAdapterState;
 
-  final List<DeviceViewModel> _smartphoneDevice =
-      bloc.deploymentDevices.where((element) => element.deviceManager is SmartphoneDeviceManager).toList();
-
-  final List<DeviceViewModel> _hardwareDevices = bloc.deploymentDevices
-      .where((element) =>
-          element.deviceManager is HardwareDeviceManager && element.deviceManager is! SmartphoneDeviceManager)
+  final List<DeviceViewModel> _smartphoneDevice = bloc.deploymentDevices
+      .where((element) => element.deviceManager is SmartphoneDeviceManager)
       .toList();
 
-  final List<DeviceViewModel> _onlineServices =
-      bloc.deploymentDevices.where((element) => element.deviceManager is OnlineServiceManager).toList();
+  final List<DeviceViewModel> _hardwareDevices = bloc.deploymentDevices
+      .where(
+        (element) =>
+            element.deviceManager is HardwareDeviceManager && element.deviceManager is! SmartphoneDeviceManager,
+      )
+      .toList();
+
+  final List<DeviceViewModel> _onlineServices = bloc.deploymentDevices
+      .where((element) => element.deviceManager is ServiceManager)
+      .toList();
 
   @override
   void initState() {
@@ -88,10 +92,10 @@ class DeviceListPageState extends State<DeviceListPage> {
                     mainAxisAlignment: MainAxisAlignment.start,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(locale.translate("pages.devices.message"),
-                          style: fs16fw600.copyWith(
-                            color: Theme.of(context).extension<CarpColors>()!.grey600,
-                          )),
+                      Text(
+                        locale.translate("pages.devices.message"),
+                        style: fs16fw600.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
+                      ),
                       const SizedBox(height: 15),
                     ],
                   ),
@@ -116,97 +120,97 @@ class DeviceListPageState extends State<DeviceListPage> {
 
   /// The list of smartphones - which is a list with only one smartphone.
   List<Widget> _smartphoneDeviceList(RPLocalizations locale) => [
-        DevicesPageListTitle(locale: locale, type: DevicesPageTypes.phone),
-        SliverList(
-          delegate: SliverChildBuilderDelegate(
-            childCount: _smartphoneDevice.length,
-            (BuildContext context, int index) => ListenableBuilder(
-              listenable: _smartphoneDevice[index],
-              builder: (BuildContext context, Widget? widget) => Center(
-                child: StudiesMaterial(
-                  backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
-                  child: _cardListBuilder(
-                    leading: _smartphoneDevice[index].icon!,
-                    title: (
-                      "${_smartphoneDevice[index].phoneInfo["model"]!} "
-                          "- ${_smartphoneDevice[index].phoneInfo["version"]!}",
-                      _smartphoneDevice[index].batteryLevel ?? 0
-                    ),
-                    subtitle: _smartphoneDevice[index].phoneInfo['name']!,
-                  ),
+    DevicesPageListTitle(locale: locale, type: DevicesPageTypes.phone),
+    SliverList(
+      delegate: SliverChildBuilderDelegate(
+        childCount: _smartphoneDevice.length,
+        (BuildContext context, int index) => ListenableBuilder(
+          listenable: _smartphoneDevice[index],
+          builder: (BuildContext context, Widget? widget) => Center(
+            child: StudiesMaterial(
+              backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
+              child: _cardListBuilder(
+                leading: _smartphoneDevice[index].icon!,
+                title: (
+                  "${_smartphoneDevice[index].phoneInfo["model"]!} "
+                      "- ${_smartphoneDevice[index].phoneInfo["version"]!}",
+                  _smartphoneDevice[index].batteryLevel ?? 0,
                 ),
+                subtitle: _smartphoneDevice[index].phoneInfo['name']!,
               ),
             ),
           ),
         ),
-      ];
+      ),
+    ),
+  ];
 
   /// The list of connected hardware devices (like a Polar sensor)
   List<Widget> _hardwareDevicesList(RPLocalizations locale) => [
-        DevicesPageListTitle(locale: locale, type: DevicesPageTypes.devices),
-        SliverList(
-          delegate: SliverChildBuilderDelegate(
-            childCount: _hardwareDevices.length,
-            (BuildContext context, int index) {
-              DeviceViewModel device = _hardwareDevices[index];
-              return _devicesPageCardStream(
-                device.statusEvents,
-                DeviceStatus.unknown,
-                () => _cardListBuilder(
-                  enableFeedback: true,
-                  leading: device.icon!,
-                  title: (locale.translate(device.typeName), device.batteryLevel ?? 0),
-                  subtitle: device.name,
-                  onTap: () async => await _hardwareDeviceClicked(device),
-                  trailing: device.getDeviceStatusIcon is Icon
-                      ? device.getDeviceStatusIcon as Icon
-                      : Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          decoration: BoxDecoration(
-                              color: CACHET.DEPLOYMENT_DEPLOYING, borderRadius: BorderRadius.circular(100)),
-                          child: Text(locale.translate(device.getDeviceStatusIcon as String),
-                              style: fs20fw700.copyWith(color: Colors.white)),
-                        ),
-                ),
-              );
-            },
+    DevicesPageListTitle(locale: locale, type: DevicesPageTypes.devices),
+    SliverList(
+      delegate: SliverChildBuilderDelegate(childCount: _hardwareDevices.length, (BuildContext context, int index) {
+        DeviceViewModel device = _hardwareDevices[index];
+        return _devicesPageCardStream(
+          device.statusEvents,
+          DeviceStatus.unknown,
+          () => _cardListBuilder(
+            enableFeedback: true,
+            leading: device.icon!,
+            title: (locale.translate(device.typeName), device.batteryLevel ?? 0),
+            subtitle: device.name,
+            onTap: () async => await _hardwareDeviceClicked(device),
+            trailing: device.getDeviceStatusIcon is Icon
+                ? device.getDeviceStatusIcon as Icon
+                : Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: CACHET.DEPLOYMENT_DEPLOYING,
+                      borderRadius: BorderRadius.circular(100),
+                    ),
+                    child: Text(
+                      locale.translate(device.getDeviceStatusIcon as String),
+                      style: fs20fw700.copyWith(color: Colors.white),
+                    ),
+                  ),
           ),
-        ),
-      ];
+        );
+      }),
+    ),
+  ];
 
   /// The list of online services (like a Location service)
   List<Widget> _onlineServicesList(RPLocalizations locale) => [
-        DevicesPageListTitle(locale: locale, type: DevicesPageTypes.services),
-        SliverList(
-          delegate: SliverChildBuilderDelegate(
-            childCount: _onlineServices.length,
-            (BuildContext context, int index) {
-              DeviceViewModel service = _onlineServices[index];
-              return _devicesPageCardStream(
-                service.statusEvents,
-                DeviceStatus.unknown,
-                () => _cardListBuilder(
-                  leading: service.icon!,
-                  title: (locale.translate(service.typeName), null),
-                  subtitle: null,
-                  onTap: () async => await _onlineServiceClicked(service),
-                  trailing: service.getServiceStatusIcon is String
-                      ? Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          decoration: BoxDecoration(
-                              color: CACHET.DEPLOYMENT_DEPLOYING, borderRadius: BorderRadius.circular(100)),
-                          child: Text(
-                            locale.translate(service.getServiceStatusIcon as String),
-                            style: fs20fw700.copyWith(color: Colors.white),
-                          ),
-                        )
-                      : service.getServiceStatusIcon as Icon,
-                ),
-              );
-            },
+    DevicesPageListTitle(locale: locale, type: DevicesPageTypes.services),
+    SliverList(
+      delegate: SliverChildBuilderDelegate(childCount: _onlineServices.length, (BuildContext context, int index) {
+        DeviceViewModel service = _onlineServices[index];
+        return _devicesPageCardStream(
+          service.statusEvents,
+          DeviceStatus.unknown,
+          () => _cardListBuilder(
+            leading: service.icon!,
+            title: (locale.translate(service.typeName), null),
+            subtitle: null,
+            onTap: () async => await _onlineServiceClicked(service),
+            trailing: service.getServiceStatusIcon is String
+                ? Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: CACHET.DEPLOYMENT_DEPLOYING,
+                      borderRadius: BorderRadius.circular(100),
+                    ),
+                    child: Text(
+                      locale.translate(service.getServiceStatusIcon as String),
+                      style: fs20fw700.copyWith(color: Colors.white),
+                    ),
+                  )
+                : service.getServiceStatusIcon as Icon,
           ),
-        ),
-      ];
+        );
+      }),
+    ),
+  ];
 
   Widget _cardListBuilder({
     bool enableFeedback = false,
@@ -215,76 +219,61 @@ class DeviceListPageState extends State<DeviceListPage> {
     String? subtitle,
     void Function()? onTap,
     Widget? trailing,
-  }) =>
-      ListTile(
-        contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-        enableFeedback: enableFeedback,
-        leading: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [leading!],
-        ),
-        title: FittedBox(
-          fit: BoxFit.scaleDown,
-          alignment: Alignment.centerLeft,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+  }) => ListTile(
+    contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+    enableFeedback: enableFeedback,
+    leading: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [leading!],
+    ),
+    title: FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerLeft,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Text(title!.$1, style: fs16fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900)),
+          SizedBox(width: 6),
+          if (title.$2 != null && title.$2! > 0) BatteryPercentage(batteryLevel: title.$2 ?? 0),
+        ],
+      ),
+    ),
+    subtitle: subtitle != null && subtitle.isNotEmpty
+        ? Column(
             mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                title!.$1,
-                style: fs16fw700.copyWith(
-                  color: Theme.of(context).extension<CarpColors>()!.grey900,
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  subtitle,
+                  style: fs12fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey700),
                 ),
               ),
-              SizedBox(width: 6),
-              if (title.$2 != null && title.$2! > 0) BatteryPercentage(batteryLevel: title.$2 ?? 0),
             ],
-          ),
-        ),
-        subtitle: subtitle != null && subtitle.isNotEmpty
-            ? Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  FittedBox(
-                    fit: BoxFit.scaleDown,
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      subtitle,
-                      style: fs12fw700.copyWith(
-                        color: Theme.of(context).extension<CarpColors>()!.grey700,
-                      ),
-                    ),
-                  ),
-                ],
-              )
-            : null,
-        trailing: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            if (trailing != null) trailing,
-          ],
-        ),
-        onTap: onTap,
-      );
+          )
+        : null,
+    trailing: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [?trailing],
+    ),
+    onTap: onTap,
+  );
 
-  Widget _devicesPageCardStream<T>(
-    Stream<T> stream,
-    T? initialData,
-    Widget Function() childBuilder,
-  ) =>
-      Center(
-        child: StudiesMaterial(
-          backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
-          child: StreamBuilder<T>(
-            stream: stream,
-            initialData: initialData,
-            builder: (context, AsyncSnapshot<T> snapshot) => childBuilder(),
-          ),
-        ),
-      );
+  Widget _devicesPageCardStream<T>(Stream<T> stream, T? initialData, Widget Function() childBuilder) => Center(
+    child: StudiesMaterial(
+      backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
+      child: StreamBuilder<T>(
+        stream: stream,
+        initialData: initialData,
+        builder: (context, AsyncSnapshot<T> snapshot) => childBuilder(),
+      ),
+    ),
+  );
 
   Future<void> _onlineServiceClicked(DeviceViewModel service) async {
     if (service.status == DeviceStatus.connected || service.status == DeviceStatus.connecting) {
@@ -293,10 +282,7 @@ class DeviceListPageState extends State<DeviceListPage> {
 
     if (!(await service.deviceManager.hasPermissions())) {
       if (service.type == HealthService.DEVICE_TYPE) {
-        Navigator.push(
-          context,
-          MaterialPageRoute<void>(builder: (context) => HealthServiceConnectPage()),
-        );
+        Navigator.push(context, MaterialPageRoute<void>(builder: (context) => HealthServiceConnectPage()));
       } else {
         await service.deviceManager.requestPermissions();
       }
@@ -320,7 +306,8 @@ class DeviceListPageState extends State<DeviceListPage> {
         );
       } else if (bluetoothAdapterState == BluetoothAdapterState.on) {
         if (device.status == DeviceStatus.connected || device.status == DeviceStatus.connecting) {
-          bool disconnect = await showDialog<bool?>(
+          bool disconnect =
+              await showDialog<bool?>(
                 context: context,
                 barrierDismissible: true,
                 builder: (context) => DisconnectionDialog(device: device),

--- a/lib/ui/pages/devices_page.authorization_dialog.dart
+++ b/lib/ui/pages/devices_page.authorization_dialog.dart
@@ -8,16 +8,15 @@ class AuthorizationDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-        scrollable: true,
-        titlePadding: const EdgeInsets.symmetric(vertical: 4),
-        insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
-        title: const DialogTitle(
-          title: "pages.devices.connection.bluetooth_authorization.title",
-        ),
-        content: SizedBox(
-          height: MediaQuery.of(context).size.height * 0.45,
-          child: authorizationInstructions(context, device),
-        ));
+      scrollable: true,
+      titlePadding: const EdgeInsets.symmetric(vertical: 4),
+      insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
+      title: const DialogTitle(title: "pages.devices.connection.bluetooth_authorization.title"),
+      content: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.45,
+        child: authorizationInstructions(context, device),
+      ),
+    );
   }
 
   Widget authorizationInstructions(BuildContext context, DeviceViewModel device) {
@@ -34,10 +33,12 @@ class AuthorizationDialog extends StatelessWidget {
                   textAlign: TextAlign.justify,
                 ),
                 Image(
-                    image: AssetImage(
-                        'assets/instructions/${Localizations.localeOf(context).languageCode}/bluetooth_enable_bar.png'),
-                    width: MediaQuery.of(context).size.height * 0.2,
-                    height: MediaQuery.of(context).size.height * 0.2),
+                  image: AssetImage(
+                    'assets/instructions/${Localizations.localeOf(context).languageCode}/bluetooth_enable_bar.png',
+                  ),
+                  width: MediaQuery.of(context).size.height * 0.2,
+                  height: MediaQuery.of(context).size.height * 0.2,
+                ),
               ],
             ),
           ),

--- a/lib/ui/pages/devices_page.bluetooth_connection_page.dart
+++ b/lib/ui/pages/devices_page.bluetooth_connection_page.dart
@@ -7,7 +7,7 @@ class BluetoothConnectionPage extends StatefulWidget {
   final DeviceViewModel device;
 
   const BluetoothConnectionPage(CurrentStep currentStep, {super.key, required this.device})
-      : _currentStep = currentStep;
+    : _currentStep = currentStep;
 
   final CurrentStep _currentStep;
 
@@ -64,9 +64,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
                           Expanded(
                             child: Padding(
                               padding: const EdgeInsets.all(8.0),
-                              child: SizedBox(
-                                child: _buildStepContent(locale),
-                              ),
+                              child: SizedBox(child: _buildStepContent(locale)),
                             ),
                           ),
                           Padding(
@@ -86,9 +84,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             if (isConnecting)
               Container(
                 color: Colors.black26,
-                child: const Center(
-                  child: CircularProgressIndicator(),
-                ),
+                child: const Center(child: CircularProgressIndicator()),
               ),
           ],
         ),
@@ -113,9 +109,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             Flexible(
               child: Text(
                 stepTitleMap[currentStep] ?? '',
-                style: fs22fw700.copyWith(
-                  color: Theme.of(context).primaryColor,
-                ),
+                style: fs22fw700.copyWith(color: Theme.of(context).primaryColor),
                 textAlign: TextAlign.center,
               ),
             ),
@@ -137,22 +131,30 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
 
   List<Widget> _buildActionButtons(RPLocalizations locale) {
     Widget buildTranslatedButton(
-        String key, VoidCallback onPressed, bool enabled, ButtonStyle? buttonStyle, TextStyle? buttonTextStyle) {
+      String key,
+      VoidCallback onPressed,
+      bool enabled,
+      ButtonStyle? buttonStyle,
+      TextStyle? buttonTextStyle,
+    ) {
       return ElevatedButton(
         onPressed: enabled ? onPressed : null,
-        child: Text(
-          locale.translate(key).toUpperCase(),
-          style: buttonTextStyle,
-        ),
+        child: Text(locale.translate(key).toUpperCase(), style: buttonTextStyle),
         style: buttonStyle,
       );
     }
 
     final stepButtonConfigs = {
       CurrentStep.scan: [
-        buildTranslatedButton("cancel", () {
-          context.pop(true);
-        }, true, null, null),
+        buildTranslatedButton(
+          "cancel",
+          () {
+            context.pop(true);
+          },
+          true,
+          null,
+          null,
+        ),
         buildTranslatedButton(
           "next",
           _connectDevice(),
@@ -161,15 +163,19 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
             padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
           ),
-          TextStyle(
-            color: Colors.white,
-          ),
+          TextStyle(color: Colors.white),
         ),
       ],
       CurrentStep.instructions: [
-        buildTranslatedButton("settings", () {
-          Platform.isAndroid ? OpenSettingsPlusAndroid().bluetooth() : OpenSettingsPlusIOS().bluetooth();
-        }, true, null, null),
+        buildTranslatedButton(
+          "settings",
+          () {
+            Platform.isAndroid ? OpenSettingsPlusAndroid().bluetooth() : OpenSettingsPlusIOS().bluetooth();
+          },
+          true,
+          null,
+          null,
+        ),
         buildTranslatedButton(
           "ok",
           () {
@@ -180,15 +186,19 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
             padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
           ),
-          TextStyle(
-            color: Colors.white,
-          ),
+          TextStyle(color: Colors.white),
         ),
       ],
       CurrentStep.done: [
-        buildTranslatedButton("back", () {
-          setState(() => currentStep = CurrentStep.scan);
-        }, true, null, null),
+        buildTranslatedButton(
+          "back",
+          () {
+            setState(() => currentStep = CurrentStep.scan);
+          },
+          true,
+          null,
+          null,
+        ),
         buildTranslatedButton(
           "done",
           () {
@@ -200,9 +210,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
             padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
           ),
-          TextStyle(
-            color: Colors.white,
-          ),
+          TextStyle(color: Colors.white),
         ),
       ],
     };
@@ -270,10 +278,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
     };
   }
 
-  Widget stepContent(
-    CurrentStep currentStep,
-    DeviceViewModel device,
-  ) {
+  Widget stepContent(CurrentStep currentStep, DeviceViewModel device) {
     if (currentStep == CurrentStep.scan) {
       return scanWidget(device, context);
     } else if (currentStep == CurrentStep.instructions) {
@@ -320,9 +325,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
                                 selected: bluetoothDevice.key == selected,
                                 title: Text(
                                   bluetoothDevice.value.device.platformName,
-                                  style: fs22fw700.copyWith(
-                                    fontSize: 20,
-                                  ),
+                                  style: fs22fw700.copyWith(fontSize: 20),
                                 ),
                                 selectedTileColor: Theme.of(context).primaryColor.withValues(alpha: 0.2),
                               ),
@@ -346,9 +349,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             child: Text.rich(
               TextSpan(
                 children: [
-                  TextSpan(
-                    text: locale.translate("pages.devices.connection.step.start.1"),
-                  ),
+                  TextSpan(text: locale.translate("pages.devices.connection.step.start.1")),
                   TextSpan(
                     text: locale.translate("pages.devices.connection.instructions"),
                     style: TextStyle(
@@ -361,17 +362,13 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
                         setState(() => currentStep = CurrentStep.instructions);
                       },
                   ),
-                  TextSpan(
-                    text: locale.translate(
-                      "pages.devices.connection.step.start.2",
-                    ),
-                  ),
+                  TextSpan(text: locale.translate("pages.devices.connection.step.start.2")),
                 ],
               ),
               style: fs22fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
               textAlign: TextAlign.center,
             ),
-          )
+          ),
         ],
       ),
     );
@@ -389,7 +386,7 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
         break;
 
       case PolarDeviceManager _
-          when device.type == PolarDevice.DEVICE_TYPE && device.polarDeviceType == PolarDeviceType.SENSE:
+          when device.type == PolarDevice.DEVICE_TYPE && device.polarDeviceType == PolarDeviceType.Verity:
         assetImage = AssetImage('assets/instructions/polar_sense_instructions.png');
         break;
 
@@ -447,9 +444,10 @@ class _BluetoothConnectionPageState extends State<BluetoothConnectionPage> {
             child: Column(
               children: [
                 Image(
-                    image: const AssetImage('assets/icons/connection_done.png'),
-                    width: MediaQuery.of(context).size.height * 0.2,
-                    height: MediaQuery.of(context).size.height * 0.2),
+                  image: const AssetImage('assets/icons/connection_done.png'),
+                  width: MediaQuery.of(context).size.height * 0.2,
+                  height: MediaQuery.of(context).size.height * 0.2,
+                ),
                 Padding(
                   padding: const EdgeInsets.only(top: 32),
                   child: Text(

--- a/lib/ui/pages/devices_page.disconnection_dialog.dart
+++ b/lib/ui/pages/devices_page.disconnection_dialog.dart
@@ -8,15 +8,12 @@ class DisconnectionDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-        scrollable: true,
-        titlePadding: const EdgeInsets.symmetric(vertical: 4),
-        insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
-        title: const DialogTitle(
-          title: "pages.devices.connection.disconnect_bluetooth.title",
-        ),
-        content: SizedBox(
-          child: disconnectBluetooth(context, device),
-        ));
+      scrollable: true,
+      titlePadding: const EdgeInsets.symmetric(vertical: 4),
+      insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
+      title: const DialogTitle(title: "pages.devices.connection.disconnect_bluetooth.title"),
+      content: SizedBox(child: disconnectBluetooth(context, device)),
+    );
   }
 
   Widget disconnectBluetooth(BuildContext context, DeviceViewModel device) {
@@ -33,9 +30,7 @@ class DisconnectionDialog extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             TextButton(
-              child: Text(
-                locale.translate("cancel"),
-              ),
+              child: Text(locale.translate("cancel")),
               onPressed: () {
                 if (context.canPop()) context.pop(false);
               },
@@ -44,12 +39,10 @@ class DisconnectionDialog extends StatelessWidget {
               onPressed: () {
                 if (context.canPop()) context.pop(true);
               },
-              child: Text(
-                locale.translate("pages.devices.connection.disconnect_bluetooth.disconnect"),
-              ),
+              child: Text(locale.translate("pages.devices.connection.disconnect_bluetooth.disconnect")),
             ),
           ],
-        )
+        ),
       ],
     );
   }

--- a/lib/ui/pages/devices_page.enable_bluetooth_dialog.dart
+++ b/lib/ui/pages/devices_page.enable_bluetooth_dialog.dart
@@ -8,14 +8,15 @@ class EnableBluetoothDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-        scrollable: true,
-        titlePadding: const EdgeInsets.symmetric(vertical: 4),
-        insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
-        title: const DialogTitle(title: "pages.devices.connection.enable_bluetooth.title"),
-        content: SizedBox(
-          height: MediaQuery.of(context).size.height * 0.45,
-          child: enableBluetoothInstructions(context, device),
-        ));
+      scrollable: true,
+      titlePadding: const EdgeInsets.symmetric(vertical: 4),
+      insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
+      title: const DialogTitle(title: "pages.devices.connection.enable_bluetooth.title"),
+      content: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.45,
+        child: enableBluetoothInstructions(context, device),
+      ),
+    );
   }
 
   Widget enableBluetoothInstructions(BuildContext context, DeviceViewModel device) {
@@ -31,9 +32,7 @@ class EnableBluetoothDialog extends StatelessWidget {
                   style: fs16fw400,
                   textAlign: TextAlign.justify,
                 ),
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16.0),
-                ),
+                Padding(padding: EdgeInsets.symmetric(vertical: 16.0)),
                 Text(
                   locale.translate("pages.devices.connection.enable_bluetooth.message2"),
                   style: fs16fw400,
@@ -44,7 +43,8 @@ class EnableBluetoothDialog extends StatelessWidget {
                     padding: EdgeInsets.symmetric(vertical: 16.0),
                     child: Image(
                       image: AssetImage(
-                          'assets/instructions/${Localizations.localeOf(context).languageCode}/bluetooth_enable_connections_bar.png'),
+                        'assets/instructions/${Localizations.localeOf(context).languageCode}/bluetooth_enable_connections_bar.png',
+                      ),
                     ),
                   ),
                 Text(

--- a/lib/ui/pages/devices_page.health_service_connect.dart
+++ b/lib/ui/pages/devices_page.health_service_connect.dart
@@ -8,7 +8,7 @@ class HealthServiceConnectPage extends StatelessWidget {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
     DeviceViewModel healthServive = bloc.deploymentDevices
-        .where((element) => element.deviceManager is OnlineServiceManager && element.type == HealthService.DEVICE_TYPE)
+        .where((element) => element.deviceManager is ServiceManager && element.type == HealthService.DEVICE_TYPE)
         .first;
 
     return Scaffold(
@@ -17,10 +17,7 @@ class HealthServiceConnectPage extends StatelessWidget {
         child: Container(
           child: Column(
             children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 18),
-                child: const CarpAppBar(),
-              ),
+              Padding(padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 18), child: const CarpAppBar()),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -44,9 +41,7 @@ class HealthServiceConnectPage extends StatelessWidget {
                           children: [
                             TextSpan(
                               text: "${locale.translate("pages.devices.type.health.instructions.page2.part1")} ",
-                              style: fs22fw700.copyWith(
-                                color: Theme.of(context).extension<CarpColors>()!.grey900,
-                              ),
+                              style: fs22fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                             ),
                             TextSpan(
                               text:
@@ -57,9 +52,7 @@ class HealthServiceConnectPage extends StatelessWidget {
                             ),
                             TextSpan(
                               text: "${locale.translate("pages.devices.type.health.instructions.page2.part2")} ",
-                              style: fs22fw700.copyWith(
-                                color: Theme.of(context).extension<CarpColors>()!.grey900,
-                              ),
+                              style: fs22fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                             ),
                             TextSpan(
                               text: "${locale.translate("pages.devices.type.health.instructions.page2.allow")} ",
@@ -71,9 +64,7 @@ class HealthServiceConnectPage extends StatelessWidget {
                               text: Platform.isAndroid
                                   ? locale.translate("pages.devices.type.health.instructions.page2.part3.android")
                                   : locale.translate("pages.devices.type.health.instructions.page2.part3.ios"),
-                              style: fs22fw700.copyWith(
-                                color: Theme.of(context).extension<CarpColors>()!.grey900,
-                              ),
+                              style: fs22fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                             ),
                           ],
                         ),
@@ -100,12 +91,7 @@ class HealthServiceConnectPage extends StatelessWidget {
               },
             ),
             ElevatedButton(
-              child: const Text(
-                "Next",
-                style: TextStyle(
-                  color: Colors.white,
-                ),
-              ),
+              child: const Text("Next", style: TextStyle(color: Colors.white)),
               style: ElevatedButton.styleFrom(
                 backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
                 padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),

--- a/lib/ui/pages/devices_page.list_title.dart
+++ b/lib/ui/pages/devices_page.list_title.dart
@@ -1,17 +1,9 @@
 part of carp_study_app;
 
-enum DevicesPageTypes {
-  phone,
-  services,
-  devices,
-}
+enum DevicesPageTypes { phone, services, devices }
 
 class DevicesPageListTitle extends StatelessWidget {
-  const DevicesPageListTitle({
-    super.key,
-    required this.locale,
-    required this.type,
-  });
+  const DevicesPageListTitle({super.key, required this.locale, required this.type});
 
   final RPLocalizations locale;
   final DevicesPageTypes type;
@@ -21,9 +13,13 @@ class DevicesPageListTitle extends StatelessWidget {
     return SliverToBoxAdapter(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 6),
-        child: Text(locale.translate("pages.devices.${type.name}.title").toUpperCase(),
-            style: fs16fw400ls1.copyWith(
-                color: Theme.of(context).extension<CarpColors>()!.grey900, fontWeight: FontWeight.bold)),
+        child: Text(
+          locale.translate("pages.devices.${type.name}.title").toUpperCase(),
+          style: fs16fw400ls1.copyWith(
+            color: Theme.of(context).extension<CarpColors>()!.grey900,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/pages/enable_connection_dialog.dart
+++ b/lib/ui/pages/enable_connection_dialog.dart
@@ -38,17 +38,19 @@ class EnableInternetConnectionDialog extends StatelessWidget {
                   textAlign: TextAlign.justify,
                 ),
                 Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16.0),
-                    child: Text(
-                      locale.translate("pages.login.internet_connection.enable_internet_connections.wifi_message"),
-                      style: fs16fw400,
-                      textAlign: TextAlign.justify,
-                    )),
+                  padding: EdgeInsets.symmetric(vertical: 16.0),
+                  child: Text(
+                    locale.translate("pages.login.internet_connection.enable_internet_connections.wifi_message"),
+                    style: fs16fw400,
+                    textAlign: TextAlign.justify,
+                  ),
+                ),
                 Padding(
                   padding: EdgeInsets.symmetric(vertical: 16.0),
                   child: Image(
                     image: AssetImage(
-                        'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_wifi_android.png'),
+                      'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_wifi_android.png',
+                    ),
                   ),
                 ),
                 Padding(
@@ -63,7 +65,8 @@ class EnableInternetConnectionDialog extends StatelessWidget {
                   padding: EdgeInsets.symmetric(vertical: 16.0),
                   child: Image(
                     image: AssetImage(
-                        'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_mobile_data_android.png'),
+                      'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_mobile_data_android.png',
+                    ),
                   ),
                 ),
               ],
@@ -109,35 +112,41 @@ class EnableInternetConnectionDialog extends StatelessWidget {
                   textAlign: TextAlign.justify,
                 ),
                 Padding(
-                    padding: EdgeInsets.symmetric(vertical: 16.0),
-                    child: Text(
-                      locale.translate("pages.login.internet_connection.enable_internet_connections.wifi_message"),
-                      style: fs16fw400,
-                      textAlign: TextAlign.justify,
-                    )),
-                Padding(
                   padding: EdgeInsets.symmetric(vertical: 16.0),
-                  child: Image(
-                    image: AssetImage(
-                        'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_wifi_ios.png'),
+                  child: Text(
+                    locale.translate("pages.login.internet_connection.enable_internet_connections.wifi_message"),
+                    style: fs16fw400,
+                    textAlign: TextAlign.justify,
                   ),
                 ),
                 Padding(
                   padding: EdgeInsets.symmetric(vertical: 16.0),
-                  child: Column(children: [
-                    Text(
-                      locale
-                          .translate("pages.login.internet_connection.enable_internet_connections.mobile_data_message"),
-                      style: fs16fw400,
-                      textAlign: TextAlign.justify,
+                  child: Image(
+                    image: AssetImage(
+                      'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_wifi_ios.png',
                     ),
-                  ]),
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16.0),
+                  child: Column(
+                    children: [
+                      Text(
+                        locale.translate(
+                          "pages.login.internet_connection.enable_internet_connections.mobile_data_message",
+                        ),
+                        style: fs16fw400,
+                        textAlign: TextAlign.justify,
+                      ),
+                    ],
+                  ),
                 ),
                 Padding(
                   padding: EdgeInsets.symmetric(vertical: 16.0),
                   child: Image(
                     image: AssetImage(
-                        'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_mobile_data_ios.png'),
+                      'assets/instructions/${Localizations.localeOf(context).languageCode}/enable_mobile_data_ios.png',
+                    ),
                   ),
                 ),
               ],

--- a/lib/ui/pages/error_page.dart
+++ b/lib/ui/pages/error_page.dart
@@ -6,22 +6,14 @@ class ErrorPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Error'),
-      ),
+      appBar: AppBar(title: const Text('Error')),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
-              "Error",
-              style: TextStyle(fontSize: 18.0),
-            ),
+            const Text("Error", style: TextStyle(fontSize: 18.0)),
             const SizedBox(height: 16.0),
-            ElevatedButton(
-              onPressed: () => context.go(CarpStudyAppState.homeRoute),
-              child: const Text('Go back'),
-            ),
+            ElevatedButton(onPressed: () => context.go(CarpStudyAppState.homeRoute), child: const Text('Go back')),
           ],
         ),
       ),

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -99,9 +99,7 @@ class HomePageState extends State<HomePage> {
 
     return Scaffold(
       backgroundColor: Theme.of(context).extension<CarpColors>()!.backgroundGray,
-      body: SafeArea(
-        child: widget.child,
-      ),
+      body: SafeArea(child: widget.child),
       bottomNavigationBar: BottomNavigationBar(
         backgroundColor: Theme.of(context).extension<CarpColors>()!.white,
         type: BottomNavigationBarType.fixed,
@@ -109,22 +107,25 @@ class HomePageState extends State<HomePage> {
         //unselectedItemColor: Theme.of(context).primaryColor.withOpacity(0.8),
         items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
-              icon: const Icon(Icons.announcement),
-              label: locale.translate('app_home.nav_bar_item.about'),
-              activeIcon: const Icon(Icons.announcement)),
+            icon: const Icon(Icons.announcement),
+            label: locale.translate('app_home.nav_bar_item.about'),
+            activeIcon: const Icon(Icons.announcement),
+          ),
           BottomNavigationBarItem(
             icon: const Icon(Icons.playlist_add_check),
             label: locale.translate('app_home.nav_bar_item.tasks'),
             activeIcon: const Icon(Icons.playlist_add_check),
           ),
           BottomNavigationBarItem(
-              icon: const Icon(Icons.leaderboard),
-              label: locale.translate('app_home.nav_bar_item.data'),
-              activeIcon: const Icon(Icons.leaderboard)),
+            icon: const Icon(Icons.leaderboard),
+            label: locale.translate('app_home.nav_bar_item.data'),
+            activeIcon: const Icon(Icons.leaderboard),
+          ),
           BottomNavigationBarItem(
-              icon: const Icon(Icons.devices_other),
-              label: locale.translate('app_home.nav_bar_item.devices'),
-              activeIcon: const Icon(Icons.devices_other)),
+            icon: const Icon(Icons.devices_other),
+            label: locale.translate('app_home.nav_bar_item.devices'),
+            activeIcon: const Icon(Icons.devices_other),
+          ),
         ],
         currentIndex: _calculateSelectedIndex(context),
         onTap: (int idx) => _onItemTapped(idx, context),

--- a/lib/ui/pages/home_page.install_health_connect_dialog.dart
+++ b/lib/ui/pages/home_page.install_health_connect_dialog.dart
@@ -9,19 +9,14 @@ class InstallHealthConnectDialog extends StatelessWidget {
     return AlertDialog(
       titlePadding: const EdgeInsets.symmetric(vertical: 4),
       insetPadding: const EdgeInsets.symmetric(vertical: 24, horizontal: 40),
-      title: const DialogTitle(
-        title: "pages.about.install_health_connect.title",
-      ),
+      title: const DialogTitle(title: "pages.about.install_health_connect.title"),
       content: Text(
         locale.translate('pages.about.install_health_connect.description'),
         style: fs16fw400,
         textAlign: TextAlign.justify,
       ),
       actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(locale.translate('cancel')),
-        ),
+        TextButton(onPressed: () => Navigator.of(context).pop(), child: Text(locale.translate('cancel'))),
         TextButton(
           child: Text(locale.translate('install')),
           onPressed: () async {
@@ -34,8 +29,9 @@ class InstallHealthConnectDialog extends StatelessWidget {
   }
 
   void _redirectToHealthConnectPlayStore() async {
-    final Uri url =
-        Uri.parse('https://play.google.com/store/apps/details?id=${LocalSettings.healthConnectPackageName}');
+    final Uri url = Uri.parse(
+      'https://play.google.com/store/apps/details?id=${LocalSettings.healthConnectPackageName}',
+    );
     var canLaunch = await canLaunchUrl(url);
     if (canLaunch) {
       await launchUrl(url);

--- a/lib/ui/pages/informed_consent_page.dart
+++ b/lib/ui/pages/informed_consent_page.dart
@@ -42,26 +42,21 @@ class InformedConsentState extends State<InformedConsentPage> {
     return Scaffold(
       key: _scaffoldKey,
       body: FutureBuilder<RPOrderedTask?>(
-        future: widget.model.getInformedConsent(localization.locale).then(
-          (document) async {
-            // No consent document configured for this study → mark accepted
-            // and navigate to /study. Set _submitted so dispose() doesn't tear
-            // the study back down.
-            if (document == null && !_submitted) {
-              _submitted = true;
-              await bloc.informedConsentHasBeenAccepted();
-              if (mounted) context.go(CarpStudyAppState.homeRoute);
-            }
-            return document;
-          },
-        ),
+        future: widget.model.getInformedConsent(localization.locale).then((document) async {
+          // No consent document configured for this study → mark accepted
+          // and navigate to /study. Set _submitted so dispose() doesn't tear
+          // the study back down.
+          if (document == null && !_submitted) {
+            _submitted = true;
+            await bloc.informedConsentHasBeenAccepted();
+            if (mounted) context.go(CarpStudyAppState.homeRoute);
+          }
+          return document;
+        }),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.done) {
             if (snapshot.hasData) {
-              return RPUITask(
-                task: snapshot.data!,
-                onSubmit: resultCallback,
-              );
+              return RPUITask(task: snapshot.data!, onSubmit: resultCallback);
             }
           }
 

--- a/lib/ui/pages/invitation_list_page.dart
+++ b/lib/ui/pages/invitation_list_page.dart
@@ -40,21 +40,12 @@ class _InvitationListPageState extends State<InvitationListPage> {
             if (snapshot.hasData) {
               child = SliverFixedExtentList(
                 itemExtent: 150,
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    return Container(
-                      child: InvitationMaterial(
-                        invitation: snapshot.data![index],
-                      ),
-                    );
-                  },
-                  childCount: snapshot.data!.length,
-                ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  return Container(child: InvitationMaterial(invitation: snapshot.data![index]));
+                }, childCount: snapshot.data!.length),
               );
             } else {
-              child = const SliverToBoxAdapter(
-                child: Center(child: CircularProgressIndicator()),
-              );
+              child = const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
             }
 
             return CustomScrollView(
@@ -88,10 +79,7 @@ class _InvitationListPageState extends State<InvitationListPage> {
                             child: Text(
                               locale.translate('invitation.invitations'),
                               textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 22.0,
-                              ),
+                              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 22.0),
                             ),
                           ),
                         ],
@@ -107,10 +95,7 @@ class _InvitationListPageState extends State<InvitationListPage> {
                       child: Text(
                         locale.translate('invitation.subtitle'),
                         textAlign: TextAlign.left,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 14.0,
-                        ),
+                        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14.0),
                       ),
                     ),
                   ),
@@ -128,19 +113,14 @@ class _InvitationListPageState extends State<InvitationListPage> {
 class InvitationMaterial extends StatelessWidget {
   final ActiveParticipationInvitation invitation;
 
-  const InvitationMaterial({
-    super.key,
-    required this.invitation,
-  });
+  const InvitationMaterial({super.key, required this.invitation});
 
   @override
   Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
     return StudiesMaterial(
       backgroundColor: Theme.of(context).extension<CarpColors>()!.white!,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12.0),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
       child: InkWell(
         onTap: () {
           context.push('${InvitationDetailsPage.route}/${invitation.participation.participantId}');

--- a/lib/ui/pages/invitation_page.dart
+++ b/lib/ui/pages/invitation_page.dart
@@ -5,11 +5,7 @@ class InvitationDetailsPage extends StatelessWidget {
   final String invitationId;
   final InvitationsViewModel model;
 
-  const InvitationDetailsPage({
-    super.key,
-    required this.invitationId,
-    required this.model,
-  });
+  const InvitationDetailsPage({super.key, required this.invitationId, required this.model});
 
   @override
   Widget build(BuildContext context) {
@@ -46,10 +42,7 @@ class InvitationDetailsPage extends StatelessWidget {
                       child: Text(
                         locale.translate('invitation.invited_to_study'),
                         textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 22.0,
-                        ),
+                        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 22.0),
                       ),
                     ),
                   ],
@@ -59,9 +52,7 @@ class InvitationDetailsPage extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 16.0),
                 child: StudiesMaterial(
                   backgroundColor: Theme.of(context).extension<CarpColors>()!.white!,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12.0),
-                  ),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
                   child: Padding(
                     padding: const EdgeInsets.all(16),
                     child: Column(
@@ -69,10 +60,7 @@ class InvitationDetailsPage extends StatelessWidget {
                       children: [
                         Text(
                           locale.translate('invitation.roles_in_the_study.title'),
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 20.0,
-                          ),
+                          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20.0),
                         ),
                         Padding(
                           padding: const EdgeInsets.only(top: 8),
@@ -91,16 +79,9 @@ class InvitationDetailsPage extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 16.0),
                   child: StudiesMaterial(
                     backgroundColor: Theme.of(context).extension<CarpColors>()!.white!,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12.0),
-                    ),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
                     child: Padding(
-                      padding: const EdgeInsets.only(
-                        right: 24.0,
-                        left: 24.0,
-                        top: 16.0,
-                        bottom: 16.0,
-                      ),
+                      padding: const EdgeInsets.only(right: 24.0, left: 24.0, top: 16.0, bottom: 16.0),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
@@ -151,10 +132,7 @@ class InvitationDetailsPage extends StatelessWidget {
               Container(
                 margin: const EdgeInsets.only(left: 16, right: 16, bottom: 16),
                 height: 56,
-                decoration: BoxDecoration(
-                  color: const Color(0xff006398),
-                  borderRadius: BorderRadius.circular(100),
-                ),
+                decoration: BoxDecoration(color: const Color(0xff006398), borderRadius: BorderRadius.circular(100)),
                 child: TextButton(
                   onPressed: () {
                     bloc.setStudyInvitation(invitation, context);

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -20,96 +20,85 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
     return Scaffold(
-        body: SafeArea(
-            child: Center(
-                child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-          Expanded(
-            child: Container(
-              margin: const EdgeInsets.symmetric(vertical: 32, horizontal: 56),
-              child: Image.asset(
-                'assets/carp_logo.png',
-                fit: BoxFit.contain,
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Container(
+                  margin: const EdgeInsets.symmetric(vertical: 32, horizontal: 56),
+                  child: Image.asset('assets/carp_logo.png', fit: BoxFit.contain),
+                ),
               ),
-            ),
-          ),
-          Container(
-            margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 64),
-            width: MediaQuery.of(context).size.width,
-            height: 56,
-            decoration: BoxDecoration(
-              color: const Color(0xff006398),
-              borderRadius: BorderRadius.circular(100),
-            ),
-            child: TextButton(
-              onPressed: () {
-                showDialog<void>(
-                  context: context,
-                  builder: (context) => QRViewExample(),
-                );
-              },
-              child: Text(
-                locale.translate("scan"),
-                style: const TextStyle(color: Color(0xffffffff), fontSize: 22),
-                textAlign: TextAlign.center,
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 64),
+                width: MediaQuery.of(context).size.width,
+                height: 56,
+                decoration: BoxDecoration(color: const Color(0xff006398), borderRadius: BorderRadius.circular(100)),
+                child: TextButton(
+                  onPressed: () {
+                    showDialog<void>(context: context, builder: (context) => QRViewExample());
+                  },
+                  child: Text(
+                    locale.translate("scan"),
+                    style: const TextStyle(color: Color(0xffffffff), fontSize: 22),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               ),
-            ),
-          ),
-          Container(
-            margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 64),
-            width: MediaQuery.of(context).size.width,
-            height: 56,
-            decoration: BoxDecoration(
-              color: const Color(0xff006398),
-              borderRadius: BorderRadius.circular(100),
-            ),
-            child: TextButton(
-              onPressed: () async {
-                bool isConnected = await bloc.checkConnectivity();
-                if (isConnected) {
-                  await bloc.backend.initialize();
-                  await bloc.backend.authenticate();
-                  if (context.mounted) context.go(CarpStudyAppState.homeRoute);
-                } else {
-                  showDialog<bool>(
-                    context: context,
-                    builder: (context) => PopScope(
-                      onPopInvokedWithResult: (didPop, result) async {
-                        WidgetsBinding.instance.addPostFrameCallback((_) async {
-                          if (didPop && result == true) {
-                            Navigator.of(context).pop();
-                          }
-                        });
-                      },
-                      child: EnableInternetConnectionDialog(),
-                    ),
-                  );
-                }
-              },
-              child: Text(
-                locale.translate("pages.login.login"),
-                style: const TextStyle(color: Color(0xffffffff), fontSize: 22),
-                textAlign: TextAlign.center,
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 64),
+                width: MediaQuery.of(context).size.width,
+                height: 56,
+                decoration: BoxDecoration(color: const Color(0xff006398), borderRadius: BorderRadius.circular(100)),
+                child: TextButton(
+                  onPressed: () async {
+                    bool isConnected = await bloc.checkConnectivity();
+                    if (isConnected) {
+                      await bloc.backend.initialize();
+                      await bloc.backend.authenticate();
+                      if (context.mounted) context.go(CarpStudyAppState.homeRoute);
+                    } else {
+                      showDialog<bool>(
+                        context: context,
+                        builder: (context) => PopScope(
+                          onPopInvokedWithResult: (didPop, result) async {
+                            WidgetsBinding.instance.addPostFrameCallback((_) async {
+                              if (didPop && result == true) {
+                                Navigator.of(context).pop();
+                              }
+                            });
+                          },
+                          child: EnableInternetConnectionDialog(),
+                        ),
+                      );
+                    }
+                  },
+                  child: Text(
+                    locale.translate("pages.login.login"),
+                    style: const TextStyle(color: Color(0xffffffff), fontSize: 22),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               ),
-            ),
+              if (bloc.backend.isAuthenticated)
+                TextButton(
+                  onPressed: () {
+                    showDialog<bool>(context: context, builder: (context) => const LogoutMessage()).then((value) async {
+                      if (value == true) {
+                        await bloc.backend.signOut();
+                        setState(() {});
+                      }
+                    });
+                  },
+                  child: Text(locale.translate('pages.login.logout')),
+                ),
+            ],
           ),
-          if (bloc.backend.isAuthenticated)
-            TextButton(
-              onPressed: () {
-                showDialog<bool>(
-                  context: context,
-                  builder: (context) => const LogoutMessage(),
-                ).then((value) async {
-                  if (value == true) {
-                    await bloc.backend.signOut();
-                    setState(() {});
-                  }
-                });
-              },
-              child: Text(locale.translate('pages.login.logout')),
-            )
-        ]))));
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/pages/message_details_page.dart
+++ b/lib/ui/pages/message_details_page.dart
@@ -4,24 +4,25 @@ class MessageDetailsPage extends StatelessWidget {
   static const String route = '/message';
   final String messageId;
 
-  const MessageDetailsPage({
-    super.key,
-    required this.messageId,
-  });
+  const MessageDetailsPage({super.key, required this.messageId});
 
   @override
   Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
-    Message message = bloc.messages.firstWhere((element) => element.id == messageId, orElse: () {
-      return Message(
+    Message message = bloc.messages.firstWhere(
+      (element) => element.id == messageId,
+      orElse: () {
+        return Message(
           id: '0',
           title: 'Unknown message',
           subTitle: 'Unknown message',
           type: MessageType.announcement,
           timestamp: DateTime.now(),
-          image: './assets/images/kids.png');
-    });
+          image: './assets/images/kids.png',
+        );
+      },
+    );
 
     return Scaffold(
       body: SafeArea(
@@ -37,10 +38,7 @@ class MessageDetailsPage extends StatelessWidget {
                 children: [
                   IconButton(
                     padding: const EdgeInsets.only(left: 26, right: 10, top: 16, bottom: 16),
-                    icon: Icon(
-                      Icons.arrow_back_ios,
-                      color: Theme.of(context).extension<CarpColors>()!.grey600,
-                    ),
+                    icon: Icon(Icons.arrow_back_ios, color: Theme.of(context).extension<CarpColors>()!.grey600),
                     onPressed: () {
                       if (context.canPop()) {
                         context.pop();
@@ -51,8 +49,10 @@ class MessageDetailsPage extends StatelessWidget {
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: Text(locale.translate(message.title!),
-                        style: fs20fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900)),
+                    child: Text(
+                      locale.translate(message.title!),
+                      style: fs20fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
+                    ),
                   ),
                   Spacer(),
                   Padding(
@@ -62,8 +62,10 @@ class MessageDetailsPage extends StatelessWidget {
                       borderRadius: BorderRadius.circular(100.0),
                       child: Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 6.0),
-                        child: Text(locale.translate(message.type.toString().split('.').last.toLowerCase()),
-                            style: fs16fw600.copyWith(color: Colors.white)),
+                        child: Text(
+                          locale.translate(message.type.toString().split('.').last.toLowerCase()),
+                          style: fs16fw600.copyWith(color: Colors.white),
+                        ),
                       ),
                     ),
                   ),
@@ -76,24 +78,26 @@ class MessageDetailsPage extends StatelessWidget {
                     message.subTitle != null
                         ? Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 6.0),
-                            child: Text(locale.translate(message.subTitle!),
-                                style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey700)),
+                            child: Text(
+                              locale.translate(message.subTitle!),
+                              style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey700),
+                            ),
                           )
                         : const SizedBox.shrink(),
                     if (message.image != null && message.image!.isNotEmpty)
-                      LayoutBuilder(builder: (context, constraints) {
-                        final screenHeight = MediaQuery.of(context).size.height;
-                        final screenWidth = MediaQuery.of(context).size.height;
-                        return ConstrainedBox(
-                          constraints: BoxConstraints(
-                            maxWidth: screenHeight,
-                            maxHeight: screenWidth,
-                          ),
-                          child: FittedBox(
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final screenHeight = MediaQuery.of(context).size.height;
+                          final screenWidth = MediaQuery.of(context).size.height;
+                          return ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: screenHeight, maxHeight: screenWidth),
+                            child: FittedBox(
                               fit: BoxFit.contain,
-                              child: bloc.appViewModel.studyPageViewModel.getMessageImage(message.image)),
-                        );
-                      }),
+                              child: bloc.appViewModel.studyPageViewModel.getMessageImage(message.image),
+                            ),
+                          );
+                        },
+                      ),
                     // DetailsBanner(message.title ?? '', message.image),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
@@ -105,7 +109,7 @@ class MessageDetailsPage extends StatelessWidget {
                               locale.translate(message.message!),
                               style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                               textAlign: TextAlign.justify,
-                            )
+                            ),
                         ],
                       ),
                     ),

--- a/lib/ui/pages/process_message_page.dart
+++ b/lib/ui/pages/process_message_page.dart
@@ -1,10 +1,6 @@
 part of carp_study_app;
 
-enum ProcessStatus {
-  done,
-  error,
-  other,
-}
+enum ProcessStatus { done, error, other }
 
 class ProcessMessagePage extends StatelessWidget {
   // Type of message to display (e.g Error, Success, Informative)
@@ -25,14 +21,15 @@ class ProcessMessagePage extends StatelessWidget {
   // Display cancel button. If true the button is displayed.
   final bool canCancel;
 
-  const ProcessMessagePage(
-      {super.key,
-      required this.statusType,
-      required this.title,
-      required this.description,
-      required this.actionFunction,
-      required this.actionText,
-      this.canCancel = true});
+  const ProcessMessagePage({
+    super.key,
+    required this.statusType,
+    required this.title,
+    required this.description,
+    required this.actionFunction,
+    required this.actionText,
+    this.canCancel = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -41,15 +38,21 @@ class ProcessMessagePage extends StatelessWidget {
       switch (statusType) {
         case ProcessStatus.done:
           image = Image(
-              image: const AssetImage('assets/icons/done.png'), height: MediaQuery.of(context).size.height * 0.35);
+            image: const AssetImage('assets/icons/done.png'),
+            height: MediaQuery.of(context).size.height * 0.35,
+          );
           break;
         case ProcessStatus.error:
           image = Image(
-              image: const AssetImage('assets/icons/error.png'), height: MediaQuery.of(context).size.height * 0.35);
+            image: const AssetImage('assets/icons/error.png'),
+            height: MediaQuery.of(context).size.height * 0.35,
+          );
           break;
         case ProcessStatus.other:
           image = Image(
-              image: const AssetImage('assets/icons/info.png'), height: MediaQuery.of(context).size.height * 0.35);
+            image: const AssetImage('assets/icons/info.png'),
+            height: MediaQuery.of(context).size.height * 0.35,
+          );
           break;
       }
 
@@ -58,52 +61,57 @@ class ProcessMessagePage extends StatelessWidget {
 
     RPLocalizations locale = RPLocalizations.of(context)!;
     return Scaffold(
-        body: Padding(
-          padding: const EdgeInsets.all(15.0),
-          child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                const SizedBox(height: 40),
-                messageImage(),
-                const SizedBox(height: 20),
-                Center(child: Text(locale.translate(title), style: fs22fw700)),
-                const SizedBox(height: 10),
-                Text(locale.translate(description), style: fs16fw600),
-              ]),
-        ),
-        bottomSheet: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      body: Padding(
+        padding: const EdgeInsets.all(15.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            canCancel == true
-                ? Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const SizedBox(width: 15),
-                      OutlinedButton(
-                          onPressed: () {
-                            Navigator.of(context).pop();
-                          },
-                          child: Text(locale.translate('cancel').toUpperCase(),
-                              style: TextStyle(color: Theme.of(context).primaryColor))),
-                      const SizedBox(width: 10),
-                    ],
-                  )
-                : const SizedBox.shrink(),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(backgroundColor: Theme.of(context).primaryColor),
-                  onPressed: () {
-                    actionFunction();
-                  },
-                  child: Text(locale.translate(actionText).toUpperCase()),
-                ),
-                const SizedBox(width: 15),
-              ],
-            ),
+            const SizedBox(height: 40),
+            messageImage(),
+            const SizedBox(height: 20),
+            Center(child: Text(locale.translate(title), style: fs22fw700)),
+            const SizedBox(height: 10),
+            Text(locale.translate(description), style: fs16fw600),
           ],
-        ));
+        ),
+      ),
+      bottomSheet: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          canCancel == true
+              ? Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const SizedBox(width: 15),
+                    OutlinedButton(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                      child: Text(
+                        locale.translate('cancel').toUpperCase(),
+                        style: TextStyle(color: Theme.of(context).primaryColor),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                  ],
+                )
+              : const SizedBox.shrink(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(backgroundColor: Theme.of(context).primaryColor),
+                onPressed: () {
+                  actionFunction();
+                },
+                child: Text(locale.translate(actionText).toUpperCase()),
+              ),
+              const SizedBox(width: 15),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/ui/pages/profile_page.dart
+++ b/lib/ui/pages/profile_page.dart
@@ -41,8 +41,10 @@ class ProfilePageState extends State<ProfilePage> {
                 TextButton.icon(
                   onPressed: () {},
                   icon: Icon(Icons.account_circle, color: Theme.of(context).primaryColor, size: 30),
-                  label: Text(locale.translate("pages.profile.title"),
-                      style: fs20fw700.copyWith(color: Theme.of(context).primaryColor)),
+                  label: Text(
+                    locale.translate("pages.profile.title"),
+                    style: fs20fw700.copyWith(color: Theme.of(context).primaryColor),
+                  ),
                 ),
                 IconButton(
                   icon: Icon(Icons.close, color: Theme.of(context).primaryColor, size: 30),
@@ -61,114 +63,75 @@ class ProfilePageState extends State<ProfilePage> {
               child: ListView(
                 padding: EdgeInsets.zero,
                 children: [
-                  _buildSectionCard(
-                    context,
-                    [
-                      _buildListTile(
-                        locale.translate('pages.profile.username'),
-                        widget.model.username,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.account_id'),
-                        widget.model.userId,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.full_name'),
-                        LocalSettings().isAnonymous
-                            ? locale.translate('pages.about.anonymous.anonymous')
-                            : widget.model.fullName,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.email'),
-                        LocalSettings().isAnonymous
-                            ? locale.translate('pages.about.anonymous.anonymous')
-                            : widget.model.email,
-                      ),
-                    ],
-                  ),
-                  _buildSectionCard(
-                    context,
-                    [
-                      _buildListTile(
-                        locale.translate('pages.profile.study_id'),
-                        widget.model.studyId,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.study_deployment_id'),
-                        widget.model.studyDeploymentId,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.study_name'),
-                        locale.translate(widget.model.studyDeploymentTitle),
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.participant_id'),
-                        widget.model.participantId,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.participant_role'),
-                        widget.model.participantRole,
-                      ),
-                      _buildListTile(
-                        locale.translate('pages.profile.device_role'),
-                        widget.model.deviceRole,
-                      ),
-                    ],
-                  ),
                   _buildSectionCard(context, [
+                    _buildListTile(locale.translate('pages.profile.username'), widget.model.username),
+                    _buildListTile(locale.translate('pages.profile.account_id'), widget.model.userId),
                     _buildListTile(
-                      locale.translate('pages.profile.app_version'),
-                      appVersion,
+                      locale.translate('pages.profile.full_name'),
+                      LocalSettings().isAnonymous
+                          ? locale.translate('pages.about.anonymous.anonymous')
+                          : widget.model.fullName,
                     ),
                     _buildListTile(
-                      locale.translate('pages.profile.app_version_code'),
-                      buildNumber,
-                    ),
-                    _buildListTile(
-                      locale.translate('pages.profile.server_name'),
-                      widget.model.currentServer,
-                    ),
-                    _buildListTile(
-                      locale.translate('pages.profile.device_id'),
-                      widget.model.deviceID,
+                      locale.translate('pages.profile.email'),
+                      LocalSettings().isAnonymous
+                          ? locale.translate('pages.about.anonymous.anonymous')
+                          : widget.model.email,
                     ),
                   ]),
-                  _buildSectionCard(
-                    context,
-                    [
-                      _buildActionListTile(
-                        leading: Icon(Icons.mail, color: Theme.of(context).primaryColor),
-                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                        title: locale.translate('pages.profile.contact'),
-                        onTap: () async {
-                          _sendEmailToContactResearcher(
-                            locale.translate(widget.model.responsibleEmail),
-                            'Support for study: ${locale.translate(widget.model.studyDeploymentTitle)} - User: ${widget.model.username}',
-                          );
-                        },
-                      ),
-                      _buildActionListTile(
-                        leading: Icon(Icons.policy, color: Theme.of(context).primaryColor),
-                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                        title: locale.translate('pages.profile.privacy'),
-                        onTap: () async {
-                          try {
-                            launchUrl(Uri.parse(CarpBackend.carpPrivacyUrl));
-                          } finally {}
-                        },
-                      ),
-                      _buildActionListTile(
-                        leading: Icon(Icons.public, color: Theme.of(context).primaryColor),
-                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                        title: locale.translate('pages.profile.study_website'),
-                        onTap: () async {
-                          try {
-                            launchUrl(Uri.parse(CarpBackend.carpWebsiteUrl));
-                          } finally {}
-                        },
-                      ),
-                    ],
-                  ),
+                  _buildSectionCard(context, [
+                    _buildListTile(locale.translate('pages.profile.study_id'), widget.model.studyId),
+                    _buildListTile(
+                      locale.translate('pages.profile.study_deployment_id'),
+                      widget.model.studyDeploymentId,
+                    ),
+                    _buildListTile(
+                      locale.translate('pages.profile.study_name'),
+                      locale.translate(widget.model.studyDeploymentTitle),
+                    ),
+                    _buildListTile(locale.translate('pages.profile.participant_id'), widget.model.participantId),
+                    _buildListTile(locale.translate('pages.profile.participant_role'), widget.model.participantRole),
+                    _buildListTile(locale.translate('pages.profile.device_role'), widget.model.deviceRole),
+                  ]),
+                  _buildSectionCard(context, [
+                    _buildListTile(locale.translate('pages.profile.app_version'), appVersion),
+                    _buildListTile(locale.translate('pages.profile.app_version_code'), buildNumber),
+                    _buildListTile(locale.translate('pages.profile.server_name'), widget.model.currentServer),
+                    _buildListTile(locale.translate('pages.profile.device_id'), widget.model.deviceID),
+                  ]),
+                  _buildSectionCard(context, [
+                    _buildActionListTile(
+                      leading: Icon(Icons.mail, color: Theme.of(context).primaryColor),
+                      trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                      title: locale.translate('pages.profile.contact'),
+                      onTap: () async {
+                        _sendEmailToContactResearcher(
+                          locale.translate(widget.model.responsibleEmail),
+                          'Support for study: ${locale.translate(widget.model.studyDeploymentTitle)} - User: ${widget.model.username}',
+                        );
+                      },
+                    ),
+                    _buildActionListTile(
+                      leading: Icon(Icons.policy, color: Theme.of(context).primaryColor),
+                      trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                      title: locale.translate('pages.profile.privacy'),
+                      onTap: () async {
+                        try {
+                          launchUrl(Uri.parse(CarpBackend.carpPrivacyUrl));
+                        } finally {}
+                      },
+                    ),
+                    _buildActionListTile(
+                      leading: Icon(Icons.public, color: Theme.of(context).primaryColor),
+                      trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                      title: locale.translate('pages.profile.study_website'),
+                      onTap: () async {
+                        try {
+                          launchUrl(Uri.parse(CarpBackend.carpWebsiteUrl));
+                        } finally {}
+                      },
+                    ),
+                  ]),
                   _buildSectionCard(context, [
                     _buildActionListTile(
                       leading: const Icon(Icons.logout, color: CACHET.RED_1),
@@ -191,7 +154,7 @@ class ProfilePageState extends State<ProfilePage> {
                         }
                       },
                     ),
-                  ])
+                  ]),
                 ],
               ),
             ),
@@ -204,9 +167,7 @@ class ProfilePageState extends State<ProfilePage> {
   Widget _buildSectionCard(BuildContext context, List<Widget> children) {
     return Card(
       color: Theme.of(context).extension<CarpColors>()!.grey50,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
@@ -226,16 +187,12 @@ class ProfilePageState extends State<ProfilePage> {
       subtitle: FittedBox(
         fit: BoxFit.scaleDown,
         alignment: Alignment.centerLeft,
-        child: Text(
-          subtitle,
-          style: fs14fw600,
-          maxLines: 1,
-        ),
+        child: Text(subtitle, style: fs14fw600, maxLines: 1),
       ),
     );
   }
 
-// Helper method to build a ListTile for actions with an icon
+  // Helper method to build a ListTile for actions with an icon
   Widget _buildActionListTile({
     required Icon leading,
     required String title,
@@ -263,8 +220,11 @@ class ProfilePageState extends State<ProfilePage> {
 
   /// Sends and email to the researcher with the name of the study + user id
   void _sendEmailToContactResearcher(String email, String subject) async {
-    final url =
-        Uri(scheme: 'mailto', path: email, queryParameters: {'subject': subject}).toString().replaceAll("+", "%20");
+    final url = Uri(
+      scheme: 'mailto',
+      path: email,
+      queryParameters: {'subject': subject},
+    ).toString().replaceAll("+", "%20");
     try {
       await launchUrl(Uri.parse(url));
     } finally {}
@@ -280,21 +240,23 @@ class ProfilePageState extends State<ProfilePage> {
           title: Text(locale.translate("pages.profile.log_out.confirmation")),
           actions: <Widget>[
             TextButton(
-                child: Text(locale.translate("NO")),
-                onPressed: () async {
-                  if (builderContext.mounted) {
-                    Navigator.of(builderContext).pop();
-                  }
-                }),
+              child: Text(locale.translate("NO")),
+              onPressed: () async {
+                if (builderContext.mounted) {
+                  Navigator.of(builderContext).pop();
+                }
+              },
+            ),
             TextButton(
-                child: Text(locale.translate("YES")),
-                onPressed: () async {
-                  if (builderContext.mounted) {
-                    await bloc.signOutAndLeaveStudy();
-                    builderContext.pop();
-                    builderContext.go(CarpStudyAppState.homeRoute);
-                  }
-                }),
+              child: Text(locale.translate("YES")),
+              onPressed: () async {
+                if (builderContext.mounted) {
+                  await bloc.signOutAndLeaveStudy();
+                  builderContext.pop();
+                  builderContext.go(CarpStudyAppState.homeRoute);
+                }
+              },
+            ),
           ],
         );
       },
@@ -319,14 +281,15 @@ class ProfilePageState extends State<ProfilePage> {
               },
             ),
             TextButton(
-                child: Text(locale.translate("YES")),
-                onPressed: () async {
-                  if (builderContext.mounted) {
-                    await bloc.leaveStudy();
-                    builderContext.pop();
-                    builderContext.go(InvitationListPage.route);
-                  }
-                }),
+              child: Text(locale.translate("YES")),
+              onPressed: () async {
+                if (builderContext.mounted) {
+                  await bloc.leaveStudy();
+                  builderContext.pop();
+                  builderContext.go(InvitationListPage.route);
+                }
+              },
+            ),
           ],
         );
       },
@@ -346,18 +309,15 @@ class ProfilePageState extends State<ProfilePage> {
 class SlidePageRoute extends PageRouteBuilder<Widget> {
   final Widget page;
   SlidePageRoute(this.page)
-      : super(
-          pageBuilder: (context, animation, secondaryAnimation) => page,
-          transitionsBuilder: (context, animation, secondaryAnimation, child) {
-            var begin = Offset(1.0, 0.0);
-            var end = Offset.zero;
-            var curve = Curves.easeInOut;
-            var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
-            var offsetAnimation = animation.drive(tween);
-            return SlideTransition(
-              position: offsetAnimation,
-              child: child,
-            );
-          },
-        );
+    : super(
+        pageBuilder: (context, animation, secondaryAnimation) => page,
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          var begin = Offset(1.0, 0.0);
+          var end = Offset.zero;
+          var curve = Curves.easeInOut;
+          var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+          var offsetAnimation = animation.drive(tween);
+          return SlideTransition(position: offsetAnimation, child: child);
+        },
+      );
 }

--- a/lib/ui/pages/qr_scanner.dart
+++ b/lib/ui/pages/qr_scanner.dart
@@ -45,20 +45,21 @@ class _QRViewExampleState extends State<QRViewExample> {
                           margin: const EdgeInsets.all(8),
                           height: 30,
                           child: ElevatedButton(
-                              onPressed: () async {
-                                await controller?.flipCamera();
-                                setState(() {});
+                            onPressed: () async {
+                              await controller?.flipCamera();
+                              setState(() {});
+                            },
+                            child: FutureBuilder(
+                              future: controller?.getCameraInfo(),
+                              builder: (context, snapshot) {
+                                if (snapshot.data != null) {
+                                  return Icon(Icons.cameraswitch);
+                                } else {
+                                  return const Text('loading');
+                                }
                               },
-                              child: FutureBuilder(
-                                future: controller?.getCameraInfo(),
-                                builder: (context, snapshot) {
-                                  if (snapshot.data != null) {
-                                    return Icon(Icons.cameraswitch);
-                                  } else {
-                                    return const Text('loading');
-                                  }
-                                },
-                              )),
+                            ),
+                          ),
                         ),
                         Container(
                           margin: const EdgeInsets.all(8),
@@ -75,7 +76,7 @@ class _QRViewExampleState extends State<QRViewExample> {
                   ],
                 ),
               ),
-            )
+            ),
           ],
         ),
       ),
@@ -84,15 +85,21 @@ class _QRViewExampleState extends State<QRViewExample> {
 
   Widget _buildQrView(BuildContext context) {
     // For this example we check how width or tall the device is and change the scanArea and overlay accordingly.
-    var scanArea =
-        (MediaQuery.of(context).size.width < 400 || MediaQuery.of(context).size.height < 400) ? 150.0 : 300.0;
+    var scanArea = (MediaQuery.of(context).size.width < 400 || MediaQuery.of(context).size.height < 400)
+        ? 150.0
+        : 300.0;
     // To ensure the Scanner view is properly sizes after rotation
     // we need to listen for Flutter SizeChanged notification and update controller
     return qr.QRView(
       key: qrKey,
       onQRViewCreated: _onQRViewCreated,
       overlay: qr.QrScannerOverlayShape(
-          borderColor: Colors.red, borderRadius: 10, borderLength: 30, borderWidth: 10, cutOutSize: scanArea),
+        borderColor: Colors.red,
+        borderRadius: 10,
+        borderLength: 30,
+        borderWidth: 10,
+        cutOutSize: scanArea,
+      ),
       onPermissionSet: (ctrl, p) => _onPermissionSet(context, ctrl, p),
     );
   }
@@ -121,9 +128,7 @@ class _QRViewExampleState extends State<QRViewExample> {
 
   void _onPermissionSet(BuildContext context, qr.QRViewController ctrl, bool p) {
     if (!p) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('no Permission')),
-      );
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('no Permission')));
     }
   }
 }

--- a/lib/ui/pages/study_details_page.dart
+++ b/lib/ui/pages/study_details_page.dart
@@ -24,10 +24,7 @@ class StudyDetailsPage extends StatelessWidget {
                 children: [
                   IconButton(
                     padding: const EdgeInsets.only(left: 26, right: 10, top: 16, bottom: 16),
-                    icon: Icon(
-                      Icons.arrow_back_ios,
-                      color: Theme.of(context).extension<CarpColors>()!.grey600,
-                    ),
+                    icon: Icon(Icons.arrow_back_ios, color: Theme.of(context).extension<CarpColors>()!.grey600),
                     onPressed: () {
                       if (context.canPop()) {
                         context.pop();
@@ -38,8 +35,10 @@ class StudyDetailsPage extends StatelessWidget {
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: Text(locale.translate(model.title),
-                        style: fs20fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary)),
+                    child: Text(
+                      locale.translate(model.title),
+                      style: fs20fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary),
+                    ),
                   ),
                 ],
               ),
@@ -49,64 +48,61 @@ class StudyDetailsPage extends StatelessWidget {
                   children: [
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 16.0),
-                      child: LayoutBuilder(builder: (context, constraints) {
-                        final screenHeight = MediaQuery.of(context).size.height;
-                        final screenWidth = MediaQuery.of(context).size.height;
-                        return ConstrainedBox(
-                            constraints: BoxConstraints(
-                              maxWidth: screenHeight,
-                              maxHeight: screenWidth,
-                            ),
-                            child: FittedBox(
-                              fit: BoxFit.contain,
-                              child: model.image,
-                            ));
-                      }),
+                      child: LayoutBuilder(
+                        builder: (context, constraints) {
+                          final screenHeight = MediaQuery.of(context).size.height;
+                          final screenWidth = MediaQuery.of(context).size.height;
+                          return ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: screenHeight, maxHeight: screenWidth),
+                            child: FittedBox(fit: BoxFit.contain, child: model.image),
+                          );
+                        },
+                      ),
                     ),
-                    _buildSectionCard(
-                      context,
-                      [
-                        _buildActionListTile(
-                          context: context,
-                          leading: Icon(Icons.mail, color: Theme.of(context).extension<CarpColors>()!.primary),
-                          trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                          title: locale.translate('pages.profile.contact'),
-                          onTap: () async {
-                            _sendEmailToContactResearcher(
-                              locale.translate(model.responsibleEmail),
-                              'Support for study: ${locale.translate(model.title)} - User: ${model.responsibleName}',
+                    _buildSectionCard(context, [
+                      _buildActionListTile(
+                        context: context,
+                        leading: Icon(Icons.mail, color: Theme.of(context).extension<CarpColors>()!.primary),
+                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                        title: locale.translate('pages.profile.contact'),
+                        onTap: () async {
+                          _sendEmailToContactResearcher(
+                            locale.translate(model.responsibleEmail),
+                            'Support for study: ${locale.translate(model.title)} - User: ${model.responsibleName}',
+                          );
+                        },
+                      ),
+                      _buildActionListTile(
+                        context: context,
+                        leading: Icon(Icons.policy, color: Theme.of(context).extension<CarpColors>()!.primary),
+                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                        title: locale.translate('pages.about.study.privacy'),
+                        onTap: () async {
+                          try {
+                            await launchUrl(Uri.parse(locale.translate(model.privacyPolicyUrl)));
+                          } catch (error) {
+                            warning(
+                              "Could not launch study description URL - ${locale.translate(model.privacyPolicyUrl)}",
                             );
-                          },
-                        ),
-                        _buildActionListTile(
-                            context: context,
-                            leading: Icon(Icons.policy, color: Theme.of(context).extension<CarpColors>()!.primary),
-                            trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                            title: locale.translate('pages.about.study.privacy'),
-                            onTap: () async {
-                              try {
-                                await launchUrl(Uri.parse(locale.translate(model.privacyPolicyUrl)));
-                              } catch (error) {
-                                warning(
-                                    "Could not launch study description URL - ${locale.translate(model.privacyPolicyUrl)}");
-                              }
-                            }),
-                        _buildActionListTile(
-                          context: context,
-                          leading: Icon(Icons.public, color: Theme.of(context).extension<CarpColors>()!.primary),
-                          trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
-                          title: locale.translate('pages.about.study.website'),
-                          onTap: () async {
-                            try {
-                              await launchUrl(Uri.parse(locale.translate(model.studyDescriptionUrl)));
-                            } catch (error) {
-                              warning(
-                                  "Could not launch study description URL - ${locale.translate(model.studyDescriptionUrl)}");
-                            }
-                          },
-                        ),
-                      ],
-                    ),
+                          }
+                        },
+                      ),
+                      _buildActionListTile(
+                        context: context,
+                        leading: Icon(Icons.public, color: Theme.of(context).extension<CarpColors>()!.primary),
+                        trailing: const Icon(Icons.arrow_forward_ios, color: CACHET.GREY_6),
+                        title: locale.translate('pages.about.study.website'),
+                        onTap: () async {
+                          try {
+                            await launchUrl(Uri.parse(locale.translate(model.studyDescriptionUrl)));
+                          } catch (error) {
+                            warning(
+                              "Could not launch study description URL - ${locale.translate(model.studyDescriptionUrl)}",
+                            );
+                          }
+                        },
+                      ),
+                    ]),
                     Padding(
                       padding: const EdgeInsets.only(top: 16.0),
                       child: Column(
@@ -149,9 +145,7 @@ class StudyDetailsPage extends StatelessWidget {
                         ],
                       ),
                     ),
-                    Divider(
-                      color: Theme.of(context).extension<CarpColors>()!.grey300,
-                    ),
+                    Divider(color: Theme.of(context).extension<CarpColors>()!.grey300),
                     Padding(
                       padding: const EdgeInsets.only(top: 16.0),
                       child: Column(
@@ -197,9 +191,7 @@ class StudyDetailsPage extends StatelessWidget {
     return Card(
       margin: EdgeInsets.zero,
       color: Theme.of(context).extension<CarpColors>()!.white,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8.0),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
@@ -213,7 +205,7 @@ class StudyDetailsPage extends StatelessWidget {
     );
   }
 
-// Helper method to build a ListTile for actions with an icon
+  // Helper method to build a ListTile for actions with an icon
   Widget _buildActionListTile({
     required BuildContext context,
     required Icon leading,
@@ -232,8 +224,11 @@ class StudyDetailsPage extends StatelessWidget {
 
   // Sends and email to the researcher with the name of the study + user id
   void _sendEmailToContactResearcher(String email, String subject) async {
-    final url =
-        Uri(scheme: 'mailto', path: email, queryParameters: {'subject': subject}).toString().replaceAll("+", "%20");
+    final url = Uri(
+      scheme: 'mailto',
+      path: email,
+      queryParameters: {'subject': subject},
+    ).toString().replaceAll("+", "%20");
     try {
       await launchUrl(Uri.parse(url));
     } finally {}

--- a/lib/ui/pages/study_page.dart
+++ b/lib/ui/pages/study_page.dart
@@ -44,10 +44,7 @@ class StudyPageState extends State<StudyPage> {
                           }
                           bloc.deploymentService.getStudyDeploymentStatus(widget.model.studyDeploymentId);
                         },
-                        child: ListView.builder(
-                          itemCount: cards.length,
-                          itemBuilder: (context, index) => cards[index],
-                        ),
+                        child: ListView.builder(itemCount: cards.length, itemBuilder: (context, index) => cards[index]),
                       );
                     },
                   );
@@ -64,13 +61,15 @@ class StudyPageState extends State<StudyPage> {
     final items = <Widget>[];
     final updateCard = _hasUpdateCard();
     items.add(updateCard);
-    items.add(_studyCard(
-      context,
-      widget.model.studyDescriptionMessage,
-      onTap: () {
-        context.push(StudyDetailsPage.route);
-      },
-    ));
+    items.add(
+      _studyCard(
+        context,
+        widget.model.studyDescriptionMessage,
+        onTap: () {
+          context.push(StudyDetailsPage.route);
+        },
+      ),
+    );
     items.add(_studyStatusCard());
     if (LocalSettings().isAnonymous) {
       items.add(AnonymousCard());
@@ -79,9 +78,11 @@ class StudyPageState extends State<StudyPage> {
       items.add(_buildAnnouncementsTitle(context));
       // Show newest announcements first: sort by timestamp descending
       final messages = List<Message>.from(widget.model.messages)..sort((a, b) => b.timestamp.compareTo(a.timestamp));
-      items.addAll(messages.map((message) {
-        return _announcementCard(context, message);
-      }).toList());
+      items.addAll(
+        messages.map((message) {
+          return _announcementCard(context, message);
+        }).toList(),
+      );
     }
     return items;
   }
@@ -89,63 +90,50 @@ class StudyPageState extends State<StudyPage> {
   Widget _hasUpdateCard() {
     RPLocalizations locale = RPLocalizations.of(context)!;
     return FutureBuilder<bool?>(
-        future: bloc.getAppHasUpdate(),
-        builder: (context, snapshot) {
-          if (snapshot.data == true) {
-            return StudiesMaterial(
-              backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
-              elevation: 8,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 16.0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Text(
-                          locale.translate('pages.about.app_update'),
-                          style: fs16fw600.copyWith(
-                            color: Theme.of(context).extension<CarpColors>()!.grey900,
-                          ),
-                        ),
+      future: bloc.getAppHasUpdate(),
+      builder: (context, snapshot) {
+        if (snapshot.data == true) {
+          return StudiesMaterial(
+            backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
+            elevation: 8,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 16.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Text(
+                        locale.translate('pages.about.app_update'),
+                        style: fs16fw600.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                       ),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.only(right: 16),
-                      child: ElevatedButton(
-                        onPressed: () async {
-                          _redirectToUpdateStore();
-                        },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: CACHET.DEPLOYMENT_DEPLOYING,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 30,
-                            vertical: 12,
-                          ),
-                        ),
-                        child: Text(
-                          locale.translate("get"),
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 16),
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        _redirectToUpdateStore();
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: CACHET.DEPLOYMENT_DEPLOYING,
+                        padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
                       ),
+                      child: Text(locale.translate("get"), style: TextStyle(color: Colors.white)),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            );
-          } else {
-            return SizedBox.shrink();
-          }
-        });
+            ),
+          );
+        } else {
+          return SizedBox.shrink();
+        }
+      },
+    );
   }
 
-  Widget _studyCard(
-    BuildContext context,
-    Message message, {
-    Function? onTap,
-  }) {
+  Widget _studyCard(BuildContext context, Message message, {Function? onTap}) {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
     // Initialization the language of the timeago package
@@ -178,8 +166,10 @@ class StudyPageState extends State<StudyPage> {
                 ),
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 8.0),
-                child: Text(locale.translate(message.title!),
-                    style: fs24fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary)),
+                child: Text(
+                  locale.translate(message.title!),
+                  style: fs24fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.primary),
+                ),
               ),
               if (message.subTitle != null && message.subTitle!.isNotEmpty)
                 Row(
@@ -187,22 +177,23 @@ class StudyPageState extends State<StudyPage> {
                     Expanded(
                       child: Text(
                         locale.translate(message.subTitle!),
-                        style: fs16fw400.copyWith(
-                          color: Theme.of(context).extension<CarpColors>()!.grey700,
-                        ),
+                        style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey700),
                       ),
                     ),
                   ],
                 ),
               if (message.message != null && message.message!.isNotEmpty)
-                Row(children: [
-                  Expanded(
+                Row(
+                  children: [
+                    Expanded(
                       child: Text(
-                    "${locale.translate(message.message!).substring(0, (message.message!.length > 150) ? 150 : null)}...",
-                    style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
-                    textAlign: TextAlign.start,
-                  )),
-                ]),
+                        "${locale.translate(message.message!).substring(0, (message.message!.length > 150) ? 150 : null)}...",
+                        style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
+                        textAlign: TextAlign.start,
+                      ),
+                    ),
+                  ],
+                ),
             ],
           ),
         ),
@@ -220,42 +211,32 @@ class StudyPageState extends State<StudyPage> {
           return StudiesMaterial(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 28),
-              child: Center(
-                child: CircularProgressIndicator(),
-              ),
+              child: Center(child: CircularProgressIndicator()),
             ),
           );
         } else if (snapshot.hasError) {
           return StudiesMaterial(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 28),
-              child: Text(
-                'Error: ${snapshot.error}',
-                textAlign: TextAlign.center,
-              ),
+              child: Text('Error: ${snapshot.error}', textAlign: TextAlign.center),
             ),
           ); // Show an error message if the future fails
         } else if (!snapshot.hasData || snapshot.data == null) {
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 28),
-            child: Center(
-              child: CircularProgressIndicator(),
-            ),
+            child: Center(child: CircularProgressIndicator()),
           ); // Handle the case where data is null
         }
 
-        final deploymentStatus = snapshot.data!.status;
+        // `status` may be null; fall back to the domain default.
+        final deploymentStatus = snapshot.data!.status ?? StudyDeploymentStatusTypes.Invited;
 
         return StudiesMaterial(
           margin: const EdgeInsets.all(16.0),
           backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           child: Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(16.0),
-            ),
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(16.0)),
             child: Row(
               children: [
                 Expanded(
@@ -267,10 +248,7 @@ class StudyPageState extends State<StudyPage> {
                           children: [
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 4),
-                              child: CircleAvatar(
-                                radius: 18,
-                                backgroundColor: studyStatusColors[deploymentStatus],
-                              ),
+                              child: CircleAvatar(radius: 18, backgroundColor: studyStatusColors[deploymentStatus]),
                             ),
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 6.0),
@@ -320,11 +298,13 @@ class StudyPageState extends State<StudyPage> {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(locale.translate('Announcements'),
-                  style: fs24fw700.copyWith(
-                    color: Theme.of(context).extension<CarpColors>()!.grey900,
-                    fontWeight: FontWeight.bold,
-                  )),
+              Text(
+                locale.translate('Announcements'),
+                style: fs24fw700.copyWith(
+                  color: Theme.of(context).extension<CarpColors>()!.grey900,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
             ],
           ),
         ),
@@ -332,11 +312,7 @@ class StudyPageState extends State<StudyPage> {
     );
   }
 
-  Widget _announcementCard(
-    BuildContext context,
-    Message message, {
-    Function? onTap,
-  }) {
+  Widget _announcementCard(BuildContext context, Message message, {Function? onTap}) {
     RPLocalizations locale = RPLocalizations.of(context)!;
 
     // Initialization the language of the timeago package
@@ -368,9 +344,7 @@ class StudyPageState extends State<StudyPage> {
                         child: Text(
                           locale.translate(message.title!),
                           overflow: TextOverflow.ellipsis,
-                          style: fs20fw700.copyWith(
-                            color: Theme.of(context).extension<CarpColors>()!.grey900,
-                          ),
+                          style: fs20fw700.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900),
                         ),
                       ),
                     ),
@@ -392,18 +366,14 @@ class StudyPageState extends State<StudyPage> {
                         Expanded(
                           child: Text(
                             locale.translate(message.subTitle!),
-                            style: fs16fw400.copyWith(
-                              color: Theme.of(context).extension<CarpColors>()!.grey700,
-                            ),
+                            style: fs16fw400.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey700),
                           ),
                         ),
                       Spacer(),
                       Text(
                         timeago.format(message.timestamp.toLocal()),
-                        style: fs10fw600.copyWith(
-                          color: Theme.of(context).extension<CarpColors>()!.grey600,
-                        ),
-                      )
+                        style: fs10fw600.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey600),
+                      ),
                     ],
                   ),
                 ),
@@ -411,13 +381,14 @@ class StudyPageState extends State<StudyPage> {
                   Row(
                     children: [
                       Expanded(
-                          child: Text(
-                        locale.translate(message.message!).length > 150
-                            ? '${locale.translate(message.message!).substring(0, 150)}...'
-                            : locale.translate(message.message!),
-                        style: fs16fw400,
-                        textAlign: TextAlign.start,
-                      )),
+                        child: Text(
+                          locale.translate(message.message!).length > 150
+                              ? '${locale.translate(message.message!).substring(0, 150)}...'
+                              : locale.translate(message.message!),
+                          style: fs16fw400,
+                          textAlign: TextAlign.start,
+                        ),
+                      ),
                     ],
                   ),
               ],

--- a/lib/ui/pages/task_list_page.dart
+++ b/lib/ui/pages/task_list_page.dart
@@ -118,50 +118,38 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                                   unselectedLabelColor: Theme.of(context).extension<CarpColors>()!.grey900,
                                   dividerColor: Colors.transparent,
                                   indicator: ShapeDecoration(
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(8),
-                                    ),
+                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
                                     color: Theme.of(context).extension<CarpColors>()!.white,
                                   ),
                                   tabs: [
                                     Container(
                                       width: double.infinity,
-                                      child: Tab(
-                                        text: locale.translate('pages.task_list.pending'),
-                                      ),
+                                      child: Tab(text: locale.translate('pages.task_list.pending')),
                                     ),
                                     Container(
                                       width: double.infinity,
-                                      child: Tab(
-                                        text: locale.translate('pages.task_list.completed'),
-                                      ),
+                                      child: Tab(text: locale.translate('pages.task_list.completed')),
                                     ),
                                   ],
                                 ),
                               ),
                             ),
                           ),
-                          if (showParticipantDataCard)
-                            SliverToBoxAdapter(
-                              child: _buildParticipantDataCard(),
-                            ),
+                          if (showParticipantDataCard) SliverToBoxAdapter(child: _buildParticipantDataCard()),
                           SliverList(
-                            delegate: SliverChildBuilderDelegate(
-                              (BuildContext context, int index) {
-                                UserTask userTask = widget.model.tasks[index];
-                                if (_tabController.index == 0) {
-                                  if (userTask.availableForUser) {
-                                    return _buildAvailableTaskCard(context, userTask);
-                                  }
-                                } else if (_tabController.index == 1) {
-                                  if (userTask.state == UserTaskState.done || userTask.state == UserTaskState.expired) {
-                                    return _buildCompletedTaskCard(context, userTask);
-                                  }
+                            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                              UserTask userTask = widget.model.tasks[index];
+                              if (_tabController.index == 0) {
+                                if (userTask.availableForUser) {
+                                  return _buildAvailableTaskCard(context, userTask);
                                 }
-                                return const SizedBox.shrink();
-                              },
-                              childCount: widget.model.tasks.length,
-                            ),
+                              } else if (_tabController.index == 1) {
+                                if (userTask.state == UserTaskState.done || userTask.state == UserTaskState.expired) {
+                                  return _buildCompletedTaskCard(context, userTask);
+                                }
+                              }
+                              return const SizedBox.shrink();
+                            }, childCount: widget.model.tasks.length),
                           ),
                         ],
                       );
@@ -182,10 +170,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
         hasBorder: true,
         borderColor: taskTypeColors["ExpectedParticipantData"]!,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.horizontal(
-            left: Radius.circular(2.0),
-            right: Radius.circular(8.0),
-          ),
+          borderRadius: BorderRadius.horizontal(left: Radius.circular(2.0), right: Radius.circular(8.0)),
         ),
         backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
         child: Padding(
@@ -201,8 +186,10 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                     children: [
                       Row(
                         children: [
-                          Icon(taskTypeIcons["ExpectedParticipantData"]!.icon,
-                              color: taskTypeColors["ExpectedParticipantData"]),
+                          Icon(
+                            taskTypeIcons["ExpectedParticipantData"]!.icon,
+                            color: taskTypeColors["ExpectedParticipantData"],
+                          ),
                           Padding(
                             padding: const EdgeInsets.only(left: 4.0),
                             child: Text(
@@ -223,17 +210,12 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                           children: [
                             Text(
                               "Participant Data",
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 16.0,
-                              ),
+                              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0),
                             ),
                             const SizedBox(height: 4.0),
                             Padding(
                               padding: const EdgeInsets.only(right: 20),
-                              child: Text(
-                                "Fill in the required participant data to continue with the study.",
-                              ),
+                              child: Text("Fill in the required participant data to continue with the study."),
                             ),
                           ],
                         ),
@@ -261,10 +243,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
           hasBorder: true,
           borderColor: taskTypeColors[userTask.type]!,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.horizontal(
-              left: Radius.circular(2.0),
-              right: Radius.circular(8.0),
-            ),
+            borderRadius: BorderRadius.horizontal(left: Radius.circular(2.0), right: Radius.circular(8.0)),
           ),
           backgroundColor: userTask.expiresIn != null && userTask.expiresIn!.inHours < 24
               ? CACHET.TASK_TO_EXPIRE_BACKGROUND
@@ -289,10 +268,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                               padding: const EdgeInsets.only(left: 4.0),
                               child: Text(
                                 userTask.type[0].toUpperCase() + userTask.type.substring(1),
-                                style: TextStyle(
-                                  color: taskTypeColors[userTask.type],
-                                  fontWeight: FontWeight.bold,
-                                ),
+                                style: TextStyle(color: taskTypeColors[userTask.type], fontWeight: FontWeight.bold),
                               ),
                             ),
                             Spacer(),
@@ -315,7 +291,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                                   fontSize: 12.0,
                                 ),
                               ),
-                            )
+                            ),
                           ],
                         ),
                         const SizedBox(height: 8.0),
@@ -326,17 +302,12 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                             children: [
                               Text(
                                 locale.translate(userTask.title),
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 16.0,
-                                ),
+                                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0),
                               ),
                               const SizedBox(height: 4.0),
                               Padding(
                                 padding: const EdgeInsets.only(right: 20),
-                                child: Text(
-                                  locale.translate(userTask.description),
-                                ),
+                                child: Text(locale.translate(userTask.description)),
                               ),
                               Padding(
                                 padding: const EdgeInsets.only(top: 8.0),
@@ -347,10 +318,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                                       padding: const EdgeInsets.only(right: 20),
                                       child: Text(
                                         _estimatedTimeSubtitle(userTask),
-                                        style: TextStyle(
-                                          color: Colors.grey,
-                                          fontSize: 12.0,
-                                        ),
+                                        style: TextStyle(color: Colors.grey, fontSize: 12.0),
                                       ),
                                     ),
                                   ],
@@ -376,13 +344,14 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
             } else {
               Timer(const Duration(seconds: 10), () {
                 userTask.onDone();
-                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
                     backgroundColor: Theme.of(context).extension<CarpColors>()!.grey700,
                     content: Text(locale.translate('Done!')),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    duration: const Duration(seconds: 1)));
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                    duration: const Duration(seconds: 1),
+                  ),
+                );
               });
             }
           }
@@ -405,13 +374,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
         } else if (taskTypeIcons[userTask.type] != null && userTask.state == UserTaskState.started) {
           return Padding(
             padding: const EdgeInsets.all(4),
-            child: SizedBox(
-              child: CircularProgressIndicator(
-                strokeWidth: 3,
-              ),
-              height: 14,
-              width: 14,
-            ),
+            child: SizedBox(child: CircularProgressIndicator(strokeWidth: 3), height: 14, width: 14),
           );
         } else if (taskTypeIcons[userTask.type] != null && userTask.state == UserTaskState.done) {
           return Icon(originalIcon.icon, color: CACHET.TASK_COMPLETED_BLUE);
@@ -459,10 +422,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
           backgroundColor: Theme.of(context).extension<CarpColors>()!.grey50!,
           hasBorder: true,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.horizontal(
-              left: Radius.circular(2.0),
-              right: Radius.circular(8.0),
-            ),
+            borderRadius: BorderRadius.horizontal(left: Radius.circular(2.0), right: Radius.circular(8.0)),
           ),
           borderColor: (userTask.state == UserTaskState.done) ? CACHET.TASK_COMPLETED_BLUE : CACHET.GREY_6,
           child: Padding(
@@ -503,7 +463,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                                     : Colors.grey,
                                 fontSize: 12.0,
                               ),
-                            )
+                            ),
                           ],
                         ),
                         const SizedBox(height: 8.0),
@@ -514,10 +474,7 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
                             children: [
                               Text(
                                 locale.translate(userTask.title),
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 16.0,
-                                ),
+                                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0),
                               ),
                             ],
                           ),
@@ -544,157 +501,67 @@ class TaskListPageState extends State<TaskListPage> with TickerProviderStateMixi
         Ink(
           width: 60,
           height: 60,
-          decoration: const ShapeDecoration(
-            color: CACHET.GREY_1,
-            shape: CircleBorder(),
-          ),
-          child: const Icon(
-            Icons.playlist_add_check,
-            color: Colors.white,
-          ),
+          decoration: const ShapeDecoration(color: CACHET.GREY_1, shape: CircleBorder()),
+          child: const Icon(Icons.playlist_add_check, color: Colors.white),
         ),
         Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-            child: Text(
-              locale.translate("pages.task_list.no_tasks"),
-              style: fs16fw600,
-              textAlign: TextAlign.center,
-            ))
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text(locale.translate("pages.task_list.no_tasks"), style: fs16fw600, textAlign: TextAlign.center),
+        ),
       ],
     );
   }
 
   static Map<String, Icon> taskTypeIcons = {
-    SurveyUserTask.SURVEY_TYPE: const Icon(
-      Icons.workspaces,
-      color: CACHET.TASK_BLUE,
-    ),
-    SurveyUserTask.COGNITIVE_ASSESSMENT_TYPE: const Icon(
-      Icons.psychology,
-      color: CACHET.LIGHT_PURPLE,
-    ),
-    SurveyUserTask.AUDIO_TYPE: const Icon(
-      Icons.hearing,
-      color: CACHET.GREEN,
-    ),
-    SurveyUserTask.VIDEO_TYPE: const Icon(
-      Icons.videocam,
-      color: CACHET.LIGHT_BLUE,
-    ),
-    SurveyUserTask.IMAGE_TYPE: const Icon(
-      Icons.image,
-      color: CACHET.YELLOW,
-    ),
-    HealthUserTask.HEALTH_ASSESSMENT_TYPE: const Icon(
-      Icons.favorite_rounded,
-      color: CACHET.RED_1,
-    ),
-    BackgroundSensingUserTask.SENSING_TYPE: const Icon(
-      Icons.sensors,
-      color: CACHET.LIGHT_BROWN,
-    ),
-    "ExpectedParticipantData": const Icon(
-      Icons.dataset,
-      color: CACHET.TASK_INPUT_DATA,
-    ),
+    AppTask.SURVEY_TYPE: const Icon(Icons.workspaces, color: CACHET.TASK_BLUE),
+    AppTask.COGNITIVE_ASSESSMENT_TYPE: const Icon(Icons.psychology, color: CACHET.LIGHT_PURPLE),
+    AppTask.AUDIO_TYPE: const Icon(Icons.hearing, color: CACHET.GREEN),
+    AppTask.VIDEO_TYPE: const Icon(Icons.videocam, color: CACHET.LIGHT_BLUE),
+    AppTask.IMAGE_TYPE: const Icon(Icons.image, color: CACHET.YELLOW),
+    AppTask.HEALTH_ASSESSMENT_TYPE: const Icon(Icons.favorite_rounded, color: CACHET.RED_1),
+    AppTask.SENSING_TYPE: const Icon(Icons.sensors, color: CACHET.LIGHT_BROWN),
+    "ExpectedParticipantData": const Icon(Icons.dataset, color: CACHET.TASK_INPUT_DATA),
   };
 
   static Map<String, Color> taskTypeColors = {
-    SurveyUserTask.SURVEY_TYPE: CACHET.TASK_BLUE,
-    SurveyUserTask.COGNITIVE_ASSESSMENT_TYPE: CACHET.LIGHT_PURPLE,
-    SurveyUserTask.AUDIO_TYPE: CACHET.GREEN,
-    SurveyUserTask.VIDEO_TYPE: CACHET.LIGHT_BLUE,
-    SurveyUserTask.IMAGE_TYPE: CACHET.YELLOW,
-    HealthUserTask.HEALTH_ASSESSMENT_TYPE: CACHET.RED_1,
-    BackgroundSensingUserTask.SENSING_TYPE: CACHET.LIGHT_BROWN,
+    AppTask.SURVEY_TYPE: CACHET.TASK_BLUE,
+    AppTask.COGNITIVE_ASSESSMENT_TYPE: CACHET.LIGHT_PURPLE,
+    AppTask.AUDIO_TYPE: CACHET.GREEN,
+    AppTask.VIDEO_TYPE: CACHET.LIGHT_BLUE,
+    AppTask.IMAGE_TYPE: CACHET.YELLOW,
+    AppTask.HEALTH_ASSESSMENT_TYPE: CACHET.RED_1,
+    AppTask.SENSING_TYPE: CACHET.LIGHT_BROWN,
     "ExpectedParticipantData": CACHET.TASK_INPUT_DATA,
   };
 
   static Map<String, Icon> measureTypeIcons = {
-    DeviceSamplingPackage.FREE_MEMORY: const Icon(
-      Icons.memory,
-      color: CACHET.GREY_4,
-    ),
-    DeviceSamplingPackage.DEVICE_INFORMATION: const Icon(
-      Icons.phone_android,
-      color: CACHET.GREY_4,
-    ),
-    DeviceSamplingPackage.BATTERY_STATE: const Icon(
-      Icons.battery_charging_full,
-      color: CACHET.GREEN,
-    ),
-    SensorSamplingPackage.STEP_COUNT: const Icon(
-      Icons.directions_walk,
-      color: CACHET.LIGHT_PURPLE,
-    ),
-    SensorSamplingPackage.ACCELERATION: const Icon(
-      Icons.adb,
-      color: CACHET.GREY_4,
-    ),
-    SensorSamplingPackage.ROTATION: const Icon(
-      Icons.adb,
-      color: CACHET.GREY_4,
-    ),
-    SensorSamplingPackage.AMBIENT_LIGHT: const Icon(
-      Icons.highlight,
-      color: CACHET.YELLOW,
-    ),
-    MediaSamplingPackage.AUDIO: const Icon(
-      Icons.mic,
-      color: CACHET.GREEN,
-    ),
-    MediaSamplingPackage.NOISE: const Icon(
-      Icons.hearing,
-      color: CACHET.YELLOW,
-    ),
-    MediaSamplingPackage.VIDEO: const Icon(
-      Icons.videocam,
-      color: CACHET.LIGHT_BLUE,
-    ),
-    MediaSamplingPackage.IMAGE: const Icon(
-      Icons.image,
-      color: CACHET.YELLOW,
-    ),
-    DeviceSamplingPackage.SCREEN_EVENT: const Icon(
-      Icons.screen_lock_portrait,
-      color: CACHET.LIGHT_PURPLE,
-    ),
-    ContextSamplingPackage.LOCATION: const Icon(
-      Icons.location_searching,
-      color: CACHET.CYAN,
-    ),
-    ContextSamplingPackage.ACTIVITY: const Icon(
-      Icons.local_fire_department,
-      color: CACHET.ORANGE,
-    ),
-    ContextSamplingPackage.WEATHER: const Icon(
-      Icons.cloud,
-      color: CACHET.LIGHT_BLUE,
-    ),
-    ContextSamplingPackage.AIR_QUALITY: const Icon(
-      Icons.air,
-      color: CACHET.GREY_3,
-    ),
-    ContextSamplingPackage.GEOFENCE: const Icon(
-      Icons.location_on,
-      color: CACHET.CYAN,
-    ),
-    ContextSamplingPackage.MOBILITY: const Icon(
-      Icons.location_on,
-      color: CACHET.ORANGE,
-    ),
-    SurveySamplingPackage.SURVEY: const Icon(
-      Icons.workspaces,
-      color: CACHET.ORANGE,
-    ),
+    DeviceSamplingPackage.FREE_MEMORY: const Icon(Icons.memory, color: CACHET.GREY_4),
+    DeviceSamplingPackage.DEVICE_INFORMATION: const Icon(Icons.phone_android, color: CACHET.GREY_4),
+    DeviceSamplingPackage.BATTERY_STATE: const Icon(Icons.battery_charging_full, color: CACHET.GREEN),
+    CarpDataTypes.STEP_COUNT: const Icon(Icons.directions_walk, color: CACHET.LIGHT_PURPLE),
+    SensorSamplingPackage.ACCELERATION: const Icon(Icons.adb, color: CACHET.GREY_4),
+    SensorSamplingPackage.ROTATION: const Icon(Icons.adb, color: CACHET.GREY_4),
+    SensorSamplingPackage.AMBIENT_LIGHT: const Icon(Icons.highlight, color: CACHET.YELLOW),
+    MediaSamplingPackage.AUDIO: const Icon(Icons.mic, color: CACHET.GREEN),
+    MediaSamplingPackage.NOISE: const Icon(Icons.hearing, color: CACHET.YELLOW),
+    MediaSamplingPackage.VIDEO: const Icon(Icons.videocam, color: CACHET.LIGHT_BLUE),
+    MediaSamplingPackage.IMAGE: const Icon(Icons.image, color: CACHET.YELLOW),
+    DeviceSamplingPackage.SCREEN_EVENT: const Icon(Icons.screen_lock_portrait, color: CACHET.LIGHT_PURPLE),
+    ContextSamplingPackage.LOCATION: const Icon(Icons.location_searching, color: CACHET.CYAN),
+    ContextSamplingPackage.ACTIVITY: const Icon(Icons.local_fire_department, color: CACHET.ORANGE),
+    ContextSamplingPackage.WEATHER: const Icon(Icons.cloud, color: CACHET.LIGHT_BLUE),
+    ContextSamplingPackage.AIR_QUALITY: const Icon(Icons.air, color: CACHET.GREY_3),
+    ContextSamplingPackage.GEOFENCE: const Icon(Icons.location_on, color: CACHET.CYAN),
+    ContextSamplingPackage.MOBILITY: const Icon(Icons.location_on, color: CACHET.ORANGE),
+    SurveySamplingPackage.SURVEY: const Icon(Icons.workspaces, color: CACHET.ORANGE),
   };
 
   static Map<UserTaskState, Icon> get taskStateIcon => {
-        UserTaskState.initialized: const Icon(Icons.stream, color: CACHET.YELLOW),
-        UserTaskState.enqueued: const Icon(Icons.notifications, color: CACHET.YELLOW),
-        UserTaskState.dequeued: const Icon(Icons.stop, color: CACHET.YELLOW),
-        UserTaskState.started: const Icon(Icons.play_arrow, color: CACHET.GREY_4),
-        UserTaskState.canceled: const Icon(Icons.pause, color: CACHET.GREY_4),
-        UserTaskState.done: const Icon(Icons.check, color: CACHET.GREEN),
-      };
+    UserTaskState.initialized: const Icon(Icons.stream, color: CACHET.YELLOW),
+    UserTaskState.enqueued: const Icon(Icons.notifications, color: CACHET.YELLOW),
+    UserTaskState.dequeued: const Icon(Icons.stop, color: CACHET.YELLOW),
+    UserTaskState.started: const Icon(Icons.play_arrow, color: CACHET.GREY_4),
+    UserTaskState.canceled: const Icon(Icons.pause, color: CACHET.GREY_4),
+    UserTaskState.done: const Icon(Icons.check, color: CACHET.GREEN),
+  };
 }

--- a/lib/ui/tasks/audio_page.dart
+++ b/lib/ui/tasks/audio_page.dart
@@ -29,9 +29,7 @@ class AudioPageState extends State<AudioPage> {
                         children: [
                           Padding(
                             padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
-                            child: const CarpAppBar(
-                              hasProfileIcon: false,
-                            ),
+                            child: const CarpAppBar(hasProfileIcon: false),
                           ),
                           Spacer(),
                           IconButton(
@@ -39,10 +37,7 @@ class AudioPageState extends State<AudioPage> {
                             onPressed: () {
                               _showCancelConfirmationDialog();
                             },
-                            icon: const Icon(
-                              Icons.close,
-                              size: 30,
-                            ),
+                            icon: const Icon(Icons.close, size: 30),
                           ),
                         ],
                       ),
@@ -59,9 +54,7 @@ class AudioPageState extends State<AudioPage> {
                                       Padding(
                                         padding: const EdgeInsets.only(bottom: 24),
                                         child: Text(
-                                          locale.translate(
-                                            widget.audioUserTask!.title,
-                                          ),
+                                          locale.translate(widget.audioUserTask!.title),
                                           style: fs22fw700.copyWith(
                                             color: Theme.of(context).extension<CarpColors>()!.primary,
                                           ),
@@ -75,9 +68,7 @@ class AudioPageState extends State<AudioPage> {
                                             child: Padding(
                                               padding: const EdgeInsets.all(8.0),
                                               child: Text(
-                                                locale.translate(
-                                                  widget.audioUserTask!.instructions,
-                                                ),
+                                                locale.translate(widget.audioUserTask!.instructions),
                                                 style: fs16fw600,
                                               ),
                                             ),
@@ -91,19 +82,12 @@ class AudioPageState extends State<AudioPage> {
                                         child: IconButton(
                                           onPressed: () => widget.audioUserTask!.onRecordStart(),
                                           padding: const EdgeInsets.all(0),
-                                          icon: const Icon(
-                                            Icons.mic,
-                                            color: Colors.white,
-                                            size: 30,
-                                          ),
+                                          icon: const Icon(Icons.mic, color: Colors.white, size: 30),
                                         ),
                                       ),
                                       Padding(
                                         padding: const EdgeInsets.only(top: 8, bottom: 40),
-                                        child: Text(
-                                          locale.translate("pages.audio_task.play"),
-                                          style: fs16fw600,
-                                        ),
+                                        child: Text(locale.translate("pages.audio_task.play"), style: fs16fw600),
                                       ),
                                     ],
                                   ),
@@ -115,9 +99,7 @@ class AudioPageState extends State<AudioPage> {
                                       Padding(
                                         padding: const EdgeInsets.only(bottom: 24),
                                         child: Text(
-                                          locale.translate(
-                                            widget.audioUserTask!.title,
-                                          ),
+                                          locale.translate(widget.audioUserTask!.title),
                                           style: fs22fw700.copyWith(
                                             color: Theme.of(context).extension<CarpColors>()!.primary,
                                           ),
@@ -148,24 +130,14 @@ class AudioPageState extends State<AudioPage> {
                                             child: IconButton(
                                               onPressed: () => widget.audioUserTask!.onRecordStop(),
                                               padding: const EdgeInsets.all(0),
-                                              icon: const Icon(
-                                                Icons.stop,
-                                                color: Colors.white,
-                                                size: 30,
-                                              ),
+                                              icon: const Icon(Icons.stop, color: Colors.white, size: 30),
                                             ),
                                           ),
                                         ],
                                       ),
                                       Padding(
-                                        padding: const EdgeInsets.only(
-                                          top: 8,
-                                          bottom: 40,
-                                        ),
-                                        child: Text(
-                                          locale.translate("pages.audio_task.recording"),
-                                          style: fs22fw700,
-                                        ),
+                                        padding: const EdgeInsets.only(top: 8, bottom: 40),
+                                        child: Text(locale.translate("pages.audio_task.recording"), style: fs22fw700),
                                       ),
                                     ],
                                   ),
@@ -185,17 +157,14 @@ class AudioPageState extends State<AudioPage> {
                                       ),
                                       Padding(
                                         padding: const EdgeInsets.only(bottom: 20),
-                                        child: Text(locale.translate('pages.audio_task.recording_completed'),
-                                            style: fs16fw600),
+                                        child: Text(
+                                          locale.translate('pages.audio_task.recording_completed'),
+                                          style: fs16fw600,
+                                        ),
                                       ),
                                       Spacer(),
                                       Padding(
-                                        padding: const EdgeInsets.only(
-                                          top: 8,
-                                          bottom: 40,
-                                          left: 20,
-                                          right: 20,
-                                        ),
+                                        padding: const EdgeInsets.only(top: 8, bottom: 40, left: 20, right: 20),
                                         child: Row(
                                           crossAxisAlignment: CrossAxisAlignment.center,
                                           children: [
@@ -229,10 +198,7 @@ class AudioPageState extends State<AudioPage> {
                                                 ),
                                               ),
                                             ),
-                                            Expanded(
-                                              flex: 1,
-                                              child: Container(),
-                                            ),
+                                            Expanded(flex: 1, child: Container()),
                                           ],
                                         ),
                                       ),
@@ -281,7 +247,7 @@ class AudioPageState extends State<AudioPage> {
                 // Exit the Ordered Task
                 context.canPop() ? context.pop() : null;
               },
-            )
+            ),
           ],
         );
       },

--- a/lib/ui/tasks/audio_task_page.dart
+++ b/lib/ui/tasks/audio_task_page.dart
@@ -18,87 +18,73 @@ class AudioTaskPageState extends State<AudioTaskPage> {
           canPop: true,
           child: Scaffold(
             body: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 15),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Row(
+              padding: const EdgeInsets.symmetric(horizontal: 15),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Row(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
+                        child: const CarpAppBar(hasProfileIcon: false),
+                      ),
+                      Spacer(),
+                      IconButton(
+                        color: Theme.of(context).extension<CarpColors>()!.grey900!,
+                        onPressed: () {
+                          _showCancelConfirmationDialog();
+                        },
+                        icon: const Icon(Icons.close, size: 30),
+                      ),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 30),
+                    child: const Image(image: AssetImage('assets/icons/audio.png'), width: 220, height: 220),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    child: Text(locale.translate(widget.audioUserTask!.title), style: fs22fw700),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
+                    child: Text(
+                      '${locale.translate(widget.audioUserTask!.description)}\n\n'
+                      '${locale.translate('pages.audio_task.play')}',
+                      style: fs16fw600,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 30),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
-                          child: const CarpAppBar(
-                            hasProfileIcon: false,
-                          ),
-                        ),
-                        Spacer(),
-                        IconButton(
-                          color: Theme.of(context).extension<CarpColors>()!.grey900!,
+                        OutlinedButton(
                           onPressed: () {
-                            _showCancelConfirmationDialog();
+                            widget.audioUserTask!.onCancel();
+                            Navigator.pop(context);
                           },
-                          icon: const Icon(
-                            Icons.close,
-                            size: 30,
+                          child: Text(locale.translate("Cancel")),
+                        ),
+                        ElevatedButton(
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute<void>(
+                              builder: (context) => AudioPage(audioUserTask: widget.audioUserTask),
+                            ),
                           ),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
+                            padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
+                          ),
+                          child: Text(locale.translate("next"), style: TextStyle(color: Colors.white)),
                         ),
                       ],
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 30),
-                      child: const Image(image: AssetImage('assets/icons/audio.png'), width: 220, height: 220),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      child: Text(locale.translate(widget.audioUserTask!.title), style: fs22fw700),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
-                      child: Text(
-                        '${locale.translate(widget.audioUserTask!.description)}\n\n'
-                        '${locale.translate('pages.audio_task.play')}',
-                        style: fs16fw600,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 30),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          OutlinedButton(
-                            onPressed: () {
-                              widget.audioUserTask!.onCancel();
-                              Navigator.pop(context);
-                            },
-                            child: Text(locale.translate("Cancel")),
-                          ),
-                          ElevatedButton(
-                            onPressed: () => Navigator.push(
-                              context,
-                              MaterialPageRoute<void>(
-                                builder: (context) => AudioPage(
-                                  audioUserTask: widget.audioUserTask,
-                                ),
-                              ),
-                            ),
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 30,
-                                vertical: 12,
-                              ),
-                            ),
-                            child: Text(
-                              locale.translate("next"),
-                              style: TextStyle(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                )),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       ),
@@ -126,7 +112,7 @@ class AudioTaskPageState extends State<AudioTaskPage> {
               onPressed: () {
                 context.pushReplacement(CarpStudyAppState.homeRoute);
               },
-            )
+            ),
           ],
         );
       },

--- a/lib/ui/tasks/camera_page.dart
+++ b/lib/ui/tasks/camera_page.dart
@@ -76,10 +76,7 @@ class CameraPageState extends State<CameraPage> {
     if (context.mounted) {
       await Navigator.of(context).push(
         MaterialPageRoute<void>(
-          builder: (context) => DisplayPicturePage(
-            file: picture,
-            videoUserTask: widget.videoUserTask,
-          ),
+          builder: (context) => DisplayPicturePage(file: picture, videoUserTask: widget.videoUserTask),
         ),
       );
     }
@@ -109,8 +106,8 @@ class CameraPageState extends State<CameraPage> {
       if (context.mounted) {
         await Navigator.of(context).push(
           MaterialPageRoute<void>(
-              builder: (context) =>
-                  DisplayPicturePage(file: video, isVideo: true, videoUserTask: widget.videoUserTask)),
+            builder: (context) => DisplayPicturePage(file: video, isVideo: true, videoUserTask: widget.videoUserTask),
+          ),
         );
       }
       setState(() {
@@ -125,9 +122,7 @@ class CameraPageState extends State<CameraPage> {
   @override
   Widget build(BuildContext context) {
     if (cameras == null || cameraInit == null) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
+      return const Center(child: CircularProgressIndicator());
     }
     return Scaffold(
       backgroundColor: Colors.black,
@@ -174,12 +169,7 @@ class CameraPageState extends State<CameraPage> {
                     Icons.close,
                     color: Colors.white,
                     size: 30,
-                    shadows: <Shadow>[
-                      Shadow(
-                        blurRadius: 3.0,
-                        color: Colors.black,
-                      ),
-                    ],
+                    shadows: <Shadow>[Shadow(blurRadius: 3.0, color: Colors.black)],
                   ),
                 ),
               ),
@@ -195,12 +185,7 @@ class CameraPageState extends State<CameraPage> {
                       icon: const Icon(
                         Icons.flip_camera_android,
                         color: Colors.white,
-                        shadows: <Shadow>[
-                          Shadow(
-                            blurRadius: 3.0,
-                            color: Colors.black,
-                          ),
-                        ],
+                        shadows: <Shadow>[Shadow(blurRadius: 3.0, color: Colors.black)],
                       ),
                     ),
                     GestureDetector(
@@ -223,10 +208,7 @@ class CameraPageState extends State<CameraPage> {
                                 Container(
                                   height: 60,
                                   width: 60,
-                                  decoration: const BoxDecoration(
-                                    shape: BoxShape.circle,
-                                    color: Colors.red,
-                                  ),
+                                  decoration: const BoxDecoration(shape: BoxShape.circle, color: Colors.red),
                                 ),
                               ],
                             )
@@ -234,12 +216,7 @@ class CameraPageState extends State<CameraPage> {
                               height: 60,
                               width: 60,
                               decoration: const BoxDecoration(
-                                boxShadow: [
-                                  BoxShadow(
-                                    color: Colors.black,
-                                    blurRadius: 3.0,
-                                  )
-                                ],
+                                boxShadow: [BoxShadow(color: Colors.black, blurRadius: 3.0)],
                                 shape: BoxShape.circle,
                                 color: Colors.white,
                               ),
@@ -250,12 +227,7 @@ class CameraPageState extends State<CameraPage> {
                       icon: Icon(
                         flashIcon,
                         color: Colors.white,
-                        shadows: <Shadow>[
-                          Shadow(
-                            blurRadius: 3.0,
-                            color: Colors.black,
-                          ),
-                        ],
+                        shadows: <Shadow>[Shadow(blurRadius: 3.0, color: Colors.black)],
                       ),
                     ),
                   ],
@@ -294,7 +266,7 @@ class CameraPageState extends State<CameraPage> {
                 Navigator.of(context).pop();
                 Navigator.of(context).pop();
               },
-            )
+            ),
           ],
         );
       },

--- a/lib/ui/tasks/camera_task_page.dart
+++ b/lib/ui/tasks/camera_task_page.dart
@@ -3,10 +3,7 @@ part of carp_study_app;
 class CameraTaskPage extends StatefulWidget {
   final VideoUserTask mediaUserTask;
 
-  const CameraTaskPage({
-    super.key,
-    required this.mediaUserTask,
-  });
+  const CameraTaskPage({super.key, required this.mediaUserTask});
 
   @override
   CameraTaskPageState createState() => CameraTaskPageState();
@@ -15,115 +12,94 @@ class CameraTaskPage extends StatefulWidget {
 class CameraTaskPageState extends State<CameraTaskPage> {
   @override
   Widget build(BuildContext context) => PopScope(
-        canPop: true,
-        child: Scaffold(
-          body: SafeArea(
-            child: StreamBuilder<UserTaskState>(
-                stream: widget.mediaUserTask.stateEvents,
-                initialData: UserTaskState.enqueued,
-                builder: (context, AsyncSnapshot<UserTaskState> snapshot) {
-                  RPLocalizations locale = RPLocalizations.of(context)!;
-                  switch (snapshot.data) {
-                    case UserTaskState.enqueued:
-                      return StreamBuilder<UserTaskState>(
-                        stream: widget.mediaUserTask.stateEvents,
-                        initialData: UserTaskState.enqueued,
-                        builder: (context, AsyncSnapshot<UserTaskState> snapshot) {
-                          return Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              Row(
+    canPop: true,
+    child: Scaffold(
+      body: SafeArea(
+        child: StreamBuilder<UserTaskState>(
+          stream: widget.mediaUserTask.stateEvents,
+          initialData: UserTaskState.enqueued,
+          builder: (context, AsyncSnapshot<UserTaskState> snapshot) {
+            RPLocalizations locale = RPLocalizations.of(context)!;
+            switch (snapshot.data) {
+              case UserTaskState.enqueued:
+                return StreamBuilder<UserTaskState>(
+                  stream: widget.mediaUserTask.stateEvents,
+                  initialData: UserTaskState.enqueued,
+                  builder: (context, AsyncSnapshot<UserTaskState> snapshot) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Row(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
+                              child: const CarpAppBar(hasProfileIcon: false),
+                            ),
+                            Spacer(),
+                            IconButton(
+                              color: Theme.of(context).extension<CarpColors>()!.grey900!,
+                              onPressed: () {
+                                _showCancelConfirmationDialog();
+                              },
+                              icon: const Icon(Icons.close, size: 30),
+                            ),
+                          ],
+                        ),
+                        Column(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 30),
+                              child: const Image(image: AssetImage('assets/icons/camera.png'), width: 220, height: 220),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 12),
+                              child: Text(locale.translate(widget.mediaUserTask.title), style: fs22fw700),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
+                              child: Text(locale.translate(widget.mediaUserTask.description), style: fs16fw600),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 30),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                                 children: [
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
-                                    child: const CarpAppBar(
-                                      hasProfileIcon: false,
-                                    ),
-                                  ),
-                                  Spacer(),
-                                  IconButton(
-                                    color: Theme.of(context).extension<CarpColors>()!.grey900!,
+                                  OutlinedButton(
                                     onPressed: () {
-                                      _showCancelConfirmationDialog();
+                                      Navigator.pop(context);
                                     },
-                                    icon: const Icon(
-                                      Icons.close,
-                                      size: 30,
+                                    child: Text(locale.translate("Cancel")),
+                                  ),
+                                  ElevatedButton(
+                                    onPressed: () => Navigator.push(
+                                      context,
+                                      MaterialPageRoute<void>(
+                                        builder: (context) => CameraPage(videoUserTask: widget.mediaUserTask),
+                                      ),
                                     ),
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
+                                      padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
+                                    ),
+                                    child: Text(locale.translate("next"), style: TextStyle(color: Colors.white)),
                                   ),
                                 ],
                               ),
-                              Column(
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 30),
-                                    child: const Image(
-                                        image: AssetImage('assets/icons/camera.png'), width: 220, height: 220),
-                                  ),
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 12),
-                                    child: Text(
-                                      locale.translate(widget.mediaUserTask.title),
-                                      style: fs22fw700,
-                                    ),
-                                  ),
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
-                                    child: Text(
-                                      locale.translate(widget.mediaUserTask.description),
-                                      style: fs16fw600,
-                                    ),
-                                  ),
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(vertical: 30),
-                                    child: Row(
-                                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                                      children: [
-                                        OutlinedButton(
-                                          onPressed: () {
-                                            Navigator.pop(context);
-                                          },
-                                          child: Text(locale.translate("Cancel")),
-                                        ),
-                                        ElevatedButton(
-                                          onPressed: () => Navigator.push(
-                                            context,
-                                            MaterialPageRoute<void>(
-                                              builder: (context) => CameraPage(
-                                                videoUserTask: widget.mediaUserTask,
-                                              ),
-                                            ),
-                                          ),
-                                          style: ElevatedButton.styleFrom(
-                                            backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
-                                            padding: const EdgeInsets.symmetric(
-                                              horizontal: 30,
-                                              vertical: 12,
-                                            ),
-                                          ),
-                                          child: Text(
-                                            locale.translate("next"),
-                                            style: TextStyle(
-                                              color: Colors.white,
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          );
-                        },
-                      );
-                    default:
-                      return const SizedBox.shrink();
-                  }
-                }),
-          ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    );
+                  },
+                );
+              default:
+                return const SizedBox.shrink();
+            }
+          },
         ),
-      );
+      ),
+    ),
+  );
 
   Future<void> _showCancelConfirmationDialog() {
     RPLocalizations locale = RPLocalizations.of(context)!;
@@ -150,7 +126,7 @@ class CameraTaskPageState extends State<CameraTaskPage> {
                 // Exit the Ordered Task
                 context.canPop() ? context.pop() : null;
               },
-            )
+            ),
           ],
         );
       },

--- a/lib/ui/tasks/display_picture_page.dart
+++ b/lib/ui/tasks/display_picture_page.dart
@@ -49,9 +49,7 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
-                  child: const CarpAppBar(
-                    hasProfileIcon: false,
-                  ),
+                  child: const CarpAppBar(hasProfileIcon: false),
                 ),
                 Spacer(),
                 IconButton(
@@ -59,10 +57,7 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
                   onPressed: () {
                     _showCancelConfirmationDialog();
                   },
-                  icon: const Icon(
-                    Icons.close,
-                    size: 30,
-                  ),
+                  icon: const Icon(Icons.close, size: 30),
                 ),
               ],
             ),
@@ -75,10 +70,11 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
                   width: MediaQuery.of(context).size.width * 0.5,
                   child: (widget.isVideo && _videoPlayerController != null)
                       ? _videoPlayerController!.value.isInitialized
-                          ? AspectRatio(
-                              aspectRatio: _videoPlayerController!.value.aspectRatio,
-                              child: VideoPlayer(_videoPlayerController!))
-                          : const CircularProgressIndicator()
+                            ? AspectRatio(
+                                aspectRatio: _videoPlayerController!.value.aspectRatio,
+                                child: VideoPlayer(_videoPlayerController!),
+                              )
+                            : const CircularProgressIndicator()
                       : Image.file(File(videoFilePath)),
                 ),
               ),
@@ -95,10 +91,7 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
                   const SizedBox(height: 40),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10),
-                    child: Text(
-                      locale.translate('pages.audio_task.recording_completed'),
-                      style: fs16fw600,
-                    ),
+                    child: Text(locale.translate('pages.audio_task.recording_completed'), style: fs16fw600),
                   ),
                   const SizedBox(height: 20),
                   Align(
@@ -153,10 +146,7 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
         return AlertDialog(
           title: Text(locale.translate("pages.audio_task.discard")),
           actions: <Widget>[
-            TextButton(
-              child: Text(locale.translate("NO")),
-              onPressed: () => Navigator.of(context).pop(),
-            ),
+            TextButton(child: Text(locale.translate("NO")), onPressed: () => Navigator.of(context).pop()),
             TextButton(
               child: Text(locale.translate("YES")),
               onPressed: () {
@@ -167,7 +157,7 @@ class DisplayPicturePageState extends State<DisplayPicturePage> {
                 Navigator.of(context).pop();
                 Navigator.of(context).pop();
               },
-            )
+            ),
           ],
         );
       },

--- a/lib/ui/tasks/participant_data_page.dart
+++ b/lib/ui/tasks/participant_data_page.dart
@@ -178,10 +178,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
       controller: widget.model._phoneNumberController,
     );
 
-    widget.model.ssnField = StepField(
-      title: "tasks.participant_data.ssn.ssn",
-      controller: widget.model._ssnController,
-    );
+    widget.model.ssnField = StepField(title: "tasks.participant_data.ssn.ssn", controller: widget.model._ssnController);
   }
 
   @override
@@ -222,13 +219,15 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
     setState(() {
       switch (currentStep) {
         case ParticipantStep.address:
-          _nextEnabled = widget.model._address1Controller.text.isNotEmpty &&
+          _nextEnabled =
+              widget.model._address1Controller.text.isNotEmpty &&
               widget.model._streetController.text.isNotEmpty &&
               widget.model._postalCodeController.text.isNotEmpty &&
               widget.model._countryController.text.isNotEmpty;
           break;
         case ParticipantStep.diagnosis:
-          _nextEnabled = widget.model._effectiveDateController.text.isNotEmpty &&
+          _nextEnabled =
+              widget.model._effectiveDateController.text.isNotEmpty &&
               widget.model._icd11CodeController.text.isNotEmpty &&
               widget.model._conclusionController.text.isNotEmpty;
           break;
@@ -266,9 +265,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                 children: [
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 10),
-                    child: const CarpAppBar(
-                      hasProfileIcon: false,
-                    ),
+                    child: const CarpAppBar(hasProfileIcon: false),
                   ),
                   Spacer(),
                   IconButton(
@@ -276,10 +273,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                     onPressed: () {
                       _showCancelConfirmationDialog();
                     },
-                    icon: const Icon(
-                      Icons.close,
-                      size: 30,
-                    ),
+                    icon: const Icon(Icons.close, size: 30),
                   ),
                 ],
               ),
@@ -293,9 +287,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.symmetric(vertical: 8),
-                          child: SizedBox(
-                            child: _buildStepContent(locale, widget.model.expectedData),
-                          ),
+                          child: SizedBox(child: _buildStepContent(locale, widget.model.expectedData)),
                         ),
                       ),
                       Padding(
@@ -337,9 +329,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
             Flexible(
               child: Text(
                 stepTitleMap[currentStep] ?? '',
-                style: fs22fw700.copyWith(
-                  color: Theme.of(context).primaryColor,
-                ),
+                style: fs22fw700.copyWith(color: Theme.of(context).primaryColor),
                 textAlign: TextAlign.center,
               ),
             ),
@@ -354,12 +344,14 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
     List<Widget> fields = [];
     switch (currentStep) {
       case ParticipantStep.presentTypes:
-        fields.add(_buildPresentTypes(
-          _includedSteps
-              .where((step) => step != ParticipantStep.presentTypes && step != ParticipantStep.review)
-              .map((step) => participantStepDescriptions[step])
-              .toList(),
-        ));
+        fields.add(
+          _buildPresentTypes(
+            _includedSteps
+                .where((step) => step != ParticipantStep.presentTypes && step != ParticipantStep.review)
+                .map((step) => participantStepDescriptions[step])
+                .toList(),
+          ),
+        );
         break;
       case ParticipantStep.address:
         fields.addAll([
@@ -392,18 +384,12 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
         fields.add(_buildField(locale, widget.model.ssnField, isCPR: true));
         break;
       case ParticipantStep.review:
-        fields.add(_buildReviewStep(
-          locale,
-          _allUsedStepFields,
-        ));
+        fields.add(_buildReviewStep(locale, _allUsedStepFields));
         break;
     }
 
     return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: fields,
-      ),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: fields),
     );
   }
 
@@ -417,11 +403,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
           child: Text(
             "\u2022 ${step ?? ''}",
             textAlign: TextAlign.start,
-            style: const TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.4,
-            ),
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600, letterSpacing: 0.4),
           ),
         );
       }).toList(),
@@ -452,20 +434,9 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
             children: [
               Text(
                 locale.translate(field),
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 0.4,
-                ),
+                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600, letterSpacing: 0.4),
               ),
-              Text(
-                input,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 0.4,
-                ),
-              ),
+              Text(input, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600, letterSpacing: 0.4)),
             ],
           ),
         );
@@ -492,10 +463,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
           widget.model._phoneNumberCodeController.text = phoneNumber.dialCode ?? '';
         },
         textFieldController: stepField.controller,
-        selectorConfig: SelectorConfig(
-          selectorType: PhoneInputSelectorType.DIALOG,
-          useBottomSheetSafeArea: true,
-        ),
+        selectorConfig: SelectorConfig(selectorType: PhoneInputSelectorType.DIALOG, useBottomSheetSafeArea: true),
         inputDecoration: _buildInputDecoration(locale, stepField, isThicc),
         ignoreBlank: false,
         autoValidateMode: AutovalidateMode.disabled,
@@ -515,10 +483,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                 width: 125,
                 child: Container(
                   decoration: BoxDecoration(
-                    border: Border.all(
-                      color: Theme.of(context).extension<CarpColors>()!.grey600!,
-                      width: 1.0,
-                    ),
+                    border: Border.all(color: Theme.of(context).extension<CarpColors>()!.grey600!, width: 1.0),
                     borderRadius: BorderRadius.circular(16.0),
                   ),
                   child: CountryCodePicker(
@@ -531,9 +496,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                     showCountryOnly: true,
                     showOnlyCountryWhenClosed: true,
                     alignLeft: false,
-                    textStyle: fs16fw600.copyWith(
-                      color: Theme.of(context).extension<CarpColors>()!.grey900!,
-                    ),
+                    textStyle: fs16fw600.copyWith(color: Theme.of(context).extension<CarpColors>()!.grey900!),
                   ),
                 ),
               ),
@@ -556,30 +519,31 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
           Padding(
             padding: const EdgeInsets.only(bottom: 16),
             child: TextFormField(
-                controller: stepField.controller,
-                focusNode: stepField.focusNode,
-                textInputAction: TextInputAction.next,
-                onFieldSubmitted: (_) {
-                  if (stepField.nextFocusNode != null) {
-                    FocusScope.of(context).requestFocus(stepField.nextFocusNode);
-                  }
-                },
-                onTap: isDatePicker
-                    ? () async {
-                        DateTime? pickedDate = await showDatePicker(
-                          context: context,
-                          initialDate: DateTime.now(),
-                          firstDate: DateTime(1900),
-                          lastDate: DateTime.now(),
-                        );
-                        if (pickedDate != null) {
-                          stepField.controller.text = "${pickedDate.toLocal()}".split(' ')[0];
-                        }
+              controller: stepField.controller,
+              focusNode: stepField.focusNode,
+              textInputAction: TextInputAction.next,
+              onFieldSubmitted: (_) {
+                if (stepField.nextFocusNode != null) {
+                  FocusScope.of(context).requestFocus(stepField.nextFocusNode);
+                }
+              },
+              onTap: isDatePicker
+                  ? () async {
+                      DateTime? pickedDate = await showDatePicker(
+                        context: context,
+                        initialDate: DateTime.now(),
+                        firstDate: DateTime(1900),
+                        lastDate: DateTime.now(),
+                      );
+                      if (pickedDate != null) {
+                        stepField.controller.text = "${pickedDate.toLocal()}".split(' ')[0];
                       }
-                    : null,
-                keyboardType: TextInputType.multiline,
-                maxLines: isThicc ? null : 1,
-                decoration: _buildInputDecoration(locale, stepField, isThicc)),
+                    }
+                  : null,
+              keyboardType: TextInputType.multiline,
+              maxLines: isThicc ? null : 1,
+              decoration: _buildInputDecoration(locale, stepField, isThicc),
+            ),
           ),
         ],
       );
@@ -588,21 +552,22 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
 
   InputDecoration _buildInputDecoration(RPLocalizations locale, StepField stepField, bool isThicc) {
     return InputDecoration(
-        labelText: locale.translate(stepField.title),
-        floatingLabelBehavior: FloatingLabelBehavior.always,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: BorderSide(color: Colors.blue),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: BorderSide(color: Colors.grey.shade300),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: BorderSide(color: Colors.blue, width: 2),
-        ),
-        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: isThicc ? 70 : 12));
+      labelText: locale.translate(stepField.title),
+      floatingLabelBehavior: FloatingLabelBehavior.always,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.blue),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.grey.shade300),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: Colors.blue, width: 2),
+      ),
+      contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: isThicc ? 70 : 12),
+    );
   }
 
   /// Builds the action buttons at the bottom of the page.
@@ -610,30 +575,44 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
   /// The "Next" button is enabled only if the required fields for the current step are filled.
   List<Widget> _buildActionButtons(RPLocalizations locale) {
     Widget buildTranslatedButton(
-        String key, VoidCallback onPressed, bool enabled, ButtonStyle? buttonStyle, TextStyle? buttonTextStyle) {
+      String key,
+      VoidCallback onPressed,
+      bool enabled,
+      ButtonStyle? buttonStyle,
+      TextStyle? buttonTextStyle,
+    ) {
       return ElevatedButton(
         onPressed: enabled ? onPressed : null,
-        child: Text(
-          locale.translate(key).toUpperCase(),
-          style: buttonTextStyle,
-        ),
+        child: Text(locale.translate(key).toUpperCase(), style: buttonTextStyle),
         style: buttonStyle,
       );
     }
 
     return [
       currentStep == ParticipantStep.presentTypes
-          ? buildTranslatedButton("cancel", () {
-              context.pop();
-            }, true, null, null)
-          : buildTranslatedButton("previous", () {
-              setState(() {
-                final idx = _includedSteps.indexOf(currentStep);
-                if (currentStep.index - 1 >= 0) {
-                  currentStep = _includedSteps[idx - 1];
-                }
-              });
-            }, true, null, null),
+          ? buildTranslatedButton(
+              "cancel",
+              () {
+                context.pop();
+              },
+              true,
+              null,
+              null,
+            )
+          : buildTranslatedButton(
+              "previous",
+              () {
+                setState(() {
+                  final idx = _includedSteps.indexOf(currentStep);
+                  if (currentStep.index - 1 >= 0) {
+                    currentStep = _includedSteps[idx - 1];
+                  }
+                });
+              },
+              true,
+              null,
+              null,
+            ),
       currentStep.index == ParticipantStep.values.length - 1
           ? buildTranslatedButton(
               "submit",
@@ -646,9 +625,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                 backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
                 padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
               ),
-              TextStyle(
-                color: Colors.white,
-              ),
+              TextStyle(color: Colors.white),
             )
           : buildTranslatedButton(
               "next",
@@ -665,9 +642,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                 backgroundColor: Theme.of(context).extension<CarpColors>()!.primary,
                 padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 12),
               ),
-              TextStyle(
-                color: Colors.white,
-              ),
+              TextStyle(color: Colors.white),
             ),
     ];
   }
@@ -680,7 +655,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
 
     final Map<ParticipantStep, Map<String, Data>> participantStepToDataType = {
       ParticipantStep.address: {
-        AddressInput.type: AddressInput(
+        InputType.ADDRESS: AddressInput(
           address1: widget.model._address1Controller.text,
           address2: widget.model._address2Controller.text,
           street: widget.model._streetController.text,
@@ -689,11 +664,11 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
         ),
       },
       ParticipantStep.diagnosis: {
-        DiagnosisInput.type: DiagnosisInput(
+        InputType.DIAGNOSIS: DiagnosisInput(
           effectiveDate: widget.model._effectiveDateController.text.isNotEmpty
-              ? DateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-                  .parse('${widget.model._effectiveDateController.text}T00:00:00Z')
-                  .toUtc()
+              ? DateFormat(
+                  "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                ).parse('${widget.model._effectiveDateController.text}T00:00:00Z').toUtc()
               : null,
           diagnosis: widget.model._diagnosisDescriptionController.text,
           icd11Code: widget.model._icd11CodeController.text,
@@ -701,20 +676,20 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
         ),
       },
       ParticipantStep.fullName: {
-        FullNameInput.type: FullNameInput(
+        InputType.FULL_NAME: FullNameInput(
           firstName: widget.model._firstNameController.text,
           middleName: widget.model._middleNameController.text,
           lastName: widget.model._lastNameController.text,
         ),
       },
       ParticipantStep.phoneNumber: {
-        PhoneNumberInput.type: PhoneNumberInput(
+        InputType.PHONE_NUMBER: PhoneNumberInput(
           countryCode: widget.model._phoneNumberCodeController.text,
           number: widget.model._phoneNumberController.text,
         ),
       },
       ParticipantStep.socialSecurityNumber: {
-        SocialSecurityNumberInput.type: SocialSecurityNumberInput(
+        InputType.SSN: SocialSecurityNumberInput(
           country: widget.model._ssnCountryController.text,
           socialSecurityNumber: widget.model._ssnController.text,
         ),
@@ -727,11 +702,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
       }
     }
 
-    bloc.setParticipantData(
-      bloc.study!.studyDeploymentId,
-      participantData,
-      bloc.study!.participantRoleName,
-    );
+    bloc.setParticipantData(bloc.study!.studyDeploymentId, participantData, bloc.study!.participantRoleName);
   }
 
   Future<void> _showCancelConfirmationDialog() {
@@ -756,7 +727,7 @@ class ParticipantDataPageState extends State<ParticipantDataPage> {
                 context.pop();
                 context.pop();
               },
-            )
+            ),
           ],
         );
       },
@@ -770,10 +741,5 @@ class StepField {
   final FocusNode? focusNode;
   final FocusNode? nextFocusNode;
 
-  StepField({
-    required this.title,
-    required this.controller,
-    this.focusNode,
-    this.nextFocusNode,
-  });
+  StepField({required this.title, required this.controller, this.focusNode, this.nextFocusNode});
 }

--- a/lib/ui/widgets/battery_icon.dart
+++ b/lib/ui/widgets/battery_icon.dart
@@ -1,11 +1,8 @@
 part of carp_study_app;
 
 class BatteryPercentage extends StatelessWidget {
-  const BatteryPercentage({
-    super.key,
-    required this.batteryLevel,
-    this.scale = 1.0,
-  }) : assert(batteryLevel >= 0 && batteryLevel <= 100, 'Battery level must be between 0 and 100');
+  const BatteryPercentage({super.key, required this.batteryLevel, this.scale = 1.0})
+    : assert(batteryLevel >= 0 && batteryLevel <= 100, 'Battery level must be between 0 and 100');
 
   // Battery level from 0 to 100
   final int batteryLevel;
@@ -16,35 +13,43 @@ class BatteryPercentage extends StatelessWidget {
   Widget build(BuildContext context) {
     double width = 25 * scale;
     double height = 12 * scale;
-    return Row(mainAxisSize: MainAxisSize.min, children: [
-      ClipRRect(
-        borderRadius: const BorderRadius.all(Radius.circular(2)),
-        child: Container(
-          decoration: BoxDecoration(
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ClipRRect(
+          borderRadius: const BorderRadius.all(Radius.circular(2)),
+          child: Container(
+            decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.secondary,
-              border: Border.all(color: Theme.of(context).primaryColor)),
-          width: width,
-          height: height,
-          child: Row(children: [
-            SizedBox(
-                width: batteryLevel != 0 ? batteryLevel * (width * 0.9 / 100) : 0,
-                height: height * 0.75,
-                child: Container(color: Theme.of(context).primaryColor)),
-          ]),
+              border: Border.all(color: Theme.of(context).primaryColor),
+            ),
+            width: width,
+            height: height,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: batteryLevel != 0 ? batteryLevel * (width * 0.9 / 100) : 0,
+                  height: height * 0.75,
+                  child: Container(color: Theme.of(context).primaryColor),
+                ),
+              ],
+            ),
+          ),
         ),
-      ),
-      ClipRRect(
-        borderRadius: const BorderRadius.all(Radius.circular(4)),
-        child: Container(
-          decoration: BoxDecoration(
+        ClipRRect(
+          borderRadius: const BorderRadius.all(Radius.circular(4)),
+          child: Container(
+            decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.secondary,
-              border: Border.all(color: Theme.of(context).primaryColor)),
-          width: 2,
-          height: 4,
+              border: Border.all(color: Theme.of(context).primaryColor),
+            ),
+            width: 2,
+            height: 4,
+          ),
         ),
-      ),
-      const SizedBox(width: 4),
-      Text("$batteryLevel%")
-    ]);
+        const SizedBox(width: 4),
+        Text("$batteryLevel%"),
+      ],
+    );
   }
 }

--- a/lib/ui/widgets/carp_app_bar.dart
+++ b/lib/ui/widgets/carp_app_bar.dart
@@ -16,19 +16,11 @@ class CarpAppBar extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.only(left: 8),
-                    child: Image.asset(
-                      'assets/carp_logo.png',
-                      fit: BoxFit.contain,
-                      height: 16,
-                    ),
+                    child: Image.asset('assets/carp_logo.png', fit: BoxFit.contain, height: 16),
                   ),
                   if (hasProfileIcon)
                     IconButton(
-                      icon: Icon(
-                        Icons.account_circle,
-                        color: Theme.of(context).primaryColor,
-                        size: 30,
-                      ),
+                      icon: Icon(Icons.account_circle, color: Theme.of(context).primaryColor, size: 30),
                       tooltip: 'Profile',
                       onPressed: () {
                         Navigator.push(context, SlidePageRoute(ProfilePage(ProfilePageViewModel())));
@@ -37,7 +29,7 @@ class CarpAppBar extends StatelessWidget {
                 ],
               ),
             ],
-          )
+          ),
         ],
       ),
     );

--- a/lib/ui/widgets/charts_legend.dart
+++ b/lib/ui/widgets/charts_legend.dart
@@ -7,8 +7,14 @@ class ChartsLegend extends StatelessWidget {
   final String? heroTag;
   final List<Color> colors;
 
-  const ChartsLegend(
-      {super.key, this.heroTag, this.iconAssetName, required this.title, this.values = const [], required this.colors});
+  const ChartsLegend({
+    super.key,
+    this.heroTag,
+    this.iconAssetName,
+    required this.title,
+    this.values = const [],
+    required this.colors,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/widgets/details_banner.dart
+++ b/lib/ui/widgets/details_banner.dart
@@ -6,19 +6,14 @@ class DetailsBanner extends StatelessWidget {
   final String? imagePath;
 
   @override
-  Widget build(
-    BuildContext context,
-  ) {
+  Widget build(BuildContext context) {
     RPLocalizations locale = RPLocalizations.of(context)!;
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         // only show this widget if there is an image = imagePath is not null and not empty
         if (imagePath != null && imagePath!.isNotEmpty)
-          SizedBox(
-            height: 300,
-            child: bloc.appViewModel.studyPageViewModel.getMessageImage(imagePath),
-          ),
+          SizedBox(height: 300, child: bloc.appViewModel.studyPageViewModel.getMessageImage(imagePath)),
         Padding(
           padding: const EdgeInsets.all(16),
           child: Stack(

--- a/lib/ui/widgets/dialog_title.dart
+++ b/lib/ui/widgets/dialog_title.dart
@@ -35,14 +35,10 @@ class DialogTitle extends StatelessWidget {
               children: [
                 Flexible(
                   child: Text(
-                    locale.translate(
-                          title,
-                        ) +
+                    locale.translate(title) +
                         (deviceName != null ? " ${locale.translate(deviceName!)} " : "") +
                         (titleEnd != null ? ' ${locale.translate(titleEnd!)}' : ""),
-                    style: fs18fw700.copyWith(
-                      color: Theme.of(context).primaryColor,
-                    ),
+                    style: fs18fw700.copyWith(color: Theme.of(context).primaryColor),
                     textAlign: TextAlign.center,
                   ),
                 ),

--- a/lib/ui/widgets/horizontal_bar.dart
+++ b/lib/ui/widgets/horizontal_bar.dart
@@ -145,14 +145,15 @@ class MyAssetsBar extends StatelessWidget {
             .entries
             .map(
               (entry) => Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      Icon(Icons.circle, color: entry.value.color, size: 12.0),
-                      Text(' ${entry.value.name!} ${entry.value.size}', style: fs12fw400, textAlign: TextAlign.right),
-                    ],
-                  )),
+                padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    Icon(Icons.circle, color: entry.value.color, size: 12.0),
+                    Text(' ${entry.value.name!} ${entry.value.size}', style: fs12fw400, textAlign: TextAlign.right),
+                  ],
+                ),
+              ),
             )
             .toList(),
       );
@@ -172,17 +173,23 @@ class MyAssetsBar extends StatelessWidget {
             .entries
             .map(
               (entry) => Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 5),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      Icon(Icons.circle, color: entry.value.color, size: 12.0),
-                      Text(' ${entry.value.size}', style: fs12fw400, textAlign: TextAlign.left),
-                      Expanded(
-                          child: Text(' ${entry.value.name!}',
-                              style: fs12fw400, textAlign: TextAlign.left, overflow: TextOverflow.ellipsis)),
-                    ],
-                  )),
+                padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 5),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    Icon(Icons.circle, color: entry.value.color, size: 12.0),
+                    Text(' ${entry.value.size}', style: fs12fw400, textAlign: TextAlign.left),
+                    Expanded(
+                      child: Text(
+                        ' ${entry.value.name!}',
+                        style: fs12fw400,
+                        textAlign: TextAlign.left,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             )
             .toList(),
       );

--- a/lib/ui/widgets/location_usage_dialog.dart
+++ b/lib/ui/widgets/location_usage_dialog.dart
@@ -24,13 +24,7 @@ class LocationUsageDialog {
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                locale.translate(message),
-                style: fs16fw400,
-                textAlign: TextAlign.justify,
-              ),
-            ],
+            children: [Text(locale.translate(message), style: fs16fw400, textAlign: TextAlign.justify)],
           ),
         ),
       ),
@@ -43,9 +37,7 @@ class LocationUsageDialog {
             backgroundColor: WidgetStateProperty.all(Theme.of(context).primaryColor),
             foregroundColor: WidgetStateProperty.all(Theme.of(context).colorScheme.onPrimary),
           ),
-          child: Text(
-            locale.translate("dialog.location.continue"),
-          ),
+          child: Text(locale.translate("dialog.location.continue")),
         ),
       ],
     );
@@ -53,12 +45,7 @@ class LocationUsageDialog {
     return Scaffold(
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            flex: 4,
-            child: locationUsageDialog,
-          ),
-        ],
+        children: [Expanded(flex: 4, child: locationUsageDialog)],
       ),
     );
   }

--- a/lib/ui/widgets/studies_material.dart
+++ b/lib/ui/widgets/studies_material.dart
@@ -17,9 +17,7 @@ class StudiesMaterial extends StatelessWidget {
     required this.child,
     this.elevation = 0,
     this.margin = const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-    this.shape = const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(8)),
-    ),
+    this.shape = const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8))),
     this.clipBehavior,
     this.hasBorder = false,
     this.hasBox = false,
@@ -39,21 +37,14 @@ class StudiesMaterial extends StatelessWidget {
         child: Container(
           decoration: hasBorder
               ? BoxDecoration(
-                  border: Border(
-                    left: BorderSide(
-                      color: borderColor,
-                      width: 4.0,
-                    ),
-                  ),
+                  border: Border(left: BorderSide(color: borderColor, width: 4.0)),
                 )
               : hasBox
-                  ? BoxDecoration(
-                      border: Border.all(
-                        color: CACHET.LIGHT_2,
-                        width: 1.0,
-                      ),
-                      borderRadius: BorderRadius.circular(16.0))
-                  : null,
+              ? BoxDecoration(
+                  border: Border.all(color: CACHET.LIGHT_2, width: 1.0),
+                  borderRadius: BorderRadius.circular(16.0),
+                )
+              : null,
           child: child,
         ),
       ),

--- a/lib/view_models/cards/activity_data_model.dart
+++ b/lib/view_models/cards/activity_data_model.dart
@@ -13,8 +13,9 @@ class ActivityCardViewModel extends SerializableViewModel<WeeklyActivities> {
       controller?.measurements.where((measurement) => measurement.data is Activity);
 
   final DateTime _startOfWeek = DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1));
-  final DateTime _endOfWeek =
-      DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1)).add(Duration(days: 6));
+  final DateTime _endOfWeek = DateTime.now()
+      .subtract(Duration(days: DateTime.now().weekday - 1))
+      .add(Duration(days: 6));
 
   String get startOfWeek => DateFormat('dd').format(_startOfWeek);
 
@@ -27,7 +28,7 @@ class ActivityCardViewModel extends SerializableViewModel<WeeklyActivities> {
   String get currentYear => DateFormat('yyyy').format(DateTime(DateTime.now().year));
 
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
 
     // listen for activity events and count the minutes
@@ -77,11 +78,7 @@ class WeeklyActivities extends DataModel {
   }
 
   /// Increase the number of minutes of doing [activityType] on [weekday] with [minutes].
-  void increaseActivityDuration(
-    ActivityType activityType,
-    int weekday,
-    int minutes,
-  ) {
+  void increaseActivityDuration(ActivityType activityType, int weekday, int minutes) {
     activities[activityType]![weekday] = (activities[activityType]![weekday] ?? 0) + minutes;
   }
 
@@ -93,8 +90,10 @@ class WeeklyActivities extends DataModel {
   @override
   String toString() {
     String str = '  TYPE\t| day | min.\n';
-    activities.forEach((type, data) =>
-        data.forEach((day, minutes) => str += '${type.toString().split(".").last}\t|  $day  |  $minutes\n'));
+    activities.forEach(
+      (type, data) =>
+          data.forEach((day, minutes) => str += '${type.toString().split(".").last}\t|  $day  |  $minutes\n'),
+    );
     return str;
   }
 }

--- a/lib/view_models/cards/heart_rate_data_model.dart
+++ b/lib/view_models/cards/heart_rate_data_model.dart
@@ -28,24 +28,22 @@ class HeartRateCardViewModel extends SerializableViewModel<HourlyHeartRate> {
       .map((measurement) => (measurement.data as MovesenseHR).hr);
 
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
 
     if (polarHRStream != null) _group.add(polarHRStream!);
     if (movesenseHRStream != null) _group.add(movesenseHRStream!);
 
-    heartRateStream?.listen(
-      (hr) {
-        if (!(hr > 0)) {
-          model.currentHeartRate = null;
-          return;
-        }
-        model.addHeartRate(DateTime.now().hour, hr);
-        if (hr > (model.maxHeartRate ?? 0)) model.maxHeartRate = hr;
-        if (hr < (model.minHeartRate ?? 100000)) model.minHeartRate = hr;
-        model.resetDataAtMidnight();
-      },
-    );
+    heartRateStream?.listen((hr) {
+      if (!(hr > 0)) {
+        model.currentHeartRate = null;
+        return;
+      }
+      model.addHeartRate(DateTime.now().hour, hr);
+      if (hr > (model.maxHeartRate ?? 0)) model.maxHeartRate = hr;
+      if (hr < (model.minHeartRate ?? 100000)) model.minHeartRate = hr;
+      model.resetDataAtMidnight();
+    });
   }
 }
 

--- a/lib/view_models/cards/measurements_data_model.dart
+++ b/lib/view_models/cards/measurements_data_model.dart
@@ -10,9 +10,8 @@ class MeasurementsCardViewModel extends ViewModel {
   Stream<Measurement>? get quietMeasureEvents =>
       controller?.measurements.where((measurement) => measurement.dataType.name != 'sensor');
 
-  /// The total sampling size
-  int get samplingSize => controller?.samplingSize == null ? 0 : controller!.samplingSize;
-  // samplingTable.values.fold(0, (prev, element) => prev + element);
+  /// The total sampling size, derived from the per-type counts in [samplingTable].
+  int get samplingSize => _samplingTable.values.fold(0, (sum, count) => sum + count);
 
   /// A table with sampling size of each measure type
   Map<String, int> get samplingTable {
@@ -31,15 +30,16 @@ class MeasurementsCardViewModel extends ViewModel {
     Map<String, int> sortedTasksTable = {}..addEntries(mapEntries);
 
     // and map to the [TaskCount] model
-    List<MeasureCount> tasksList =
-        sortedTasksTable.entries.map((entry) => MeasureCount(entry.key, entry.value)).toList();
+    List<MeasureCount> tasksList = sortedTasksTable.entries
+        .map((entry) => MeasureCount(entry.key, entry.value))
+        .toList();
 
     return tasksList;
   }
 
   MeasurementsCardViewModel() : super();
 
-  // void init(SmartphoneDeploymentController controller) {
+  // void init(SmartphoneStudyController controller) {
   //   super.init(controller);
 
   //   // listen to incoming events in order to count the measure types

--- a/lib/view_models/cards/mobility_data_model.dart
+++ b/lib/view_models/cards/mobility_data_model.dart
@@ -11,8 +11,9 @@ class MobilityCardViewModel extends SerializableViewModel<WeeklyMobility> {
       controller?.measurements.where((measurement) => measurement.data is Mobility);
 
   final DateTime _startOfWeek = DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1));
-  final DateTime _endOfWeek =
-      DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1)).add(Duration(days: 6));
+  final DateTime _endOfWeek = DateTime.now()
+      .subtract(Duration(days: DateTime.now().weekday - 1))
+      .add(Duration(days: 6));
 
   String get startOfWeek => DateFormat('dd').format(_startOfWeek);
 
@@ -26,7 +27,7 @@ class MobilityCardViewModel extends SerializableViewModel<WeeklyMobility> {
 
   MobilityCardViewModel();
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
 
     // listen for mobility events and update the features
@@ -59,8 +60,12 @@ class WeeklyMobility extends DataModel {
   void setMobilityFeatures(Mobility data) {
     DateTime day = data.date ?? DateTime.now();
 
-    weekMobility[day.weekday] = DailyMobility(day.weekday, data.numberOfPlaces ?? 0,
-        data.homeStay != null && data.homeStay! > 0 ? (100 * (data.homeStay!)).toInt() : 0, data.distanceTraveled ?? 0);
+    weekMobility[day.weekday] = DailyMobility(
+      day.weekday,
+      data.numberOfPlaces ?? 0,
+      data.homeStay != null && data.homeStay! > 0 ? (100 * (data.homeStay!)).toInt() : 0,
+      data.distanceTraveled ?? 0,
+    );
   }
 
   @override

--- a/lib/view_models/cards/steps_data_model.dart
+++ b/lib/view_models/cards/steps_data_model.dart
@@ -13,8 +13,9 @@ class StepsCardViewModel extends SerializableViewModel<WeeklySteps> {
   List<DailySteps> get steps => model.steps;
 
   final DateTime _startOfWeek = DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1));
-  final DateTime _endOfWeek =
-      DateTime.now().subtract(Duration(days: DateTime.now().weekday - 1)).add(Duration(days: 6));
+  final DateTime _endOfWeek = DateTime.now()
+      .subtract(Duration(days: DateTime.now().weekday - 1))
+      .add(Duration(days: 6));
 
   String get startOfWeek => DateFormat('dd').format(_startOfWeek);
 
@@ -31,7 +32,7 @@ class StepsCardViewModel extends SerializableViewModel<WeeklySteps> {
       controller?.measurements.where((dataPoint) => dataPoint.data is StepCount);
 
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
 
     // listen for pedometer events and count them

--- a/lib/view_models/cards/study_progress_data_model.dart
+++ b/lib/view_models/cards/study_progress_data_model.dart
@@ -26,7 +26,7 @@ class StudyProgressCardViewModel extends ViewModel {
   StudyProgressCardViewModel() : super();
 
   @override
-  Future<void> init(SmartphoneDeploymentController ctrl) async {
+  Future<void> init(SmartphoneStudyController ctrl) async {
     super.init(ctrl);
     updateProgress();
   }

--- a/lib/view_models/cards/task_data_model.dart
+++ b/lib/view_models/cards/task_data_model.dart
@@ -17,19 +17,17 @@ class TaskCardViewModel extends ViewModel {
   Map<String, int> get tasksTable {
     Map<String, int> tasksTable = {};
 
-    AppTaskController()
-        .userTaskQueue
+    AppTaskController().userTaskQueue
         .where((task) => task.state == UserTaskState.done && task.type == taskType)
         .forEach((task) {
-      if (!tasksTable.containsKey(task.title)) tasksTable[task.title] = 0;
-      tasksTable[task.title] = tasksTable[task.title]! + 1;
-    });
+          if (!tasksTable.containsKey(task.title)) tasksTable[task.title] = 0;
+          tasksTable[task.title] = tasksTable[task.title]! + 1;
+        });
     return tasksTable;
   }
 
   /// The total number of tasks done of type [taskType].
-  int get tasksDone => AppTaskController()
-      .userTaskQueue
+  int get tasksDone => AppTaskController().userTaskQueue
       .where((task) => task.state == UserTaskState.done && task.type == taskType)
       .length;
 

--- a/lib/view_models/data_visualization_page_model.dart
+++ b/lib/view_models/data_visualization_page_model.dart
@@ -5,10 +5,10 @@ class DataVisualizationPageViewModel extends ViewModel {
   final StepsCardViewModel _stepsCardDataModel = StepsCardViewModel();
   final MeasurementsCardViewModel _measuresCardDataModel = MeasurementsCardViewModel();
   final MobilityCardViewModel _mobilityCardDataModel = MobilityCardViewModel();
-  final TaskCardViewModel _surveysCardDataModel = TaskCardViewModel(SurveyUserTask.SURVEY_TYPE);
-  final TaskCardViewModel _audioCardDataModel = TaskCardViewModel(SurveyUserTask.AUDIO_TYPE);
-  final TaskCardViewModel _videoCardDataModel = TaskCardViewModel(SurveyUserTask.VIDEO_TYPE);
-  final TaskCardViewModel _imageCardDataModel = TaskCardViewModel(SurveyUserTask.IMAGE_TYPE);
+  final TaskCardViewModel _surveysCardDataModel = TaskCardViewModel(AppTask.SURVEY_TYPE);
+  final TaskCardViewModel _audioCardDataModel = TaskCardViewModel(AppTask.AUDIO_TYPE);
+  final TaskCardViewModel _videoCardDataModel = TaskCardViewModel(AppTask.VIDEO_TYPE);
+  final TaskCardViewModel _imageCardDataModel = TaskCardViewModel(AppTask.IMAGE_TYPE);
   final StudyProgressCardViewModel _studyProgressCardDataModel = StudyProgressCardViewModel();
   final HeartRateCardViewModel _heartRateCardDataModel = HeartRateCardViewModel();
 
@@ -37,7 +37,7 @@ class DataVisualizationPageViewModel extends ViewModel {
   DataVisualizationPageViewModel();
 
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
     _activityCardDataModel.init(ctrl);
     _stepsCardDataModel.init(ctrl);

--- a/lib/view_models/device_view_models.dart
+++ b/lib/view_models/device_view_models.dart
@@ -15,7 +15,7 @@ class DeviceViewModel extends ViewModel {
   DeviceViewModel(this.deviceManager) : super();
 
   /// The type of this device.
-  String? get type => deviceManager.type;
+  String? get type => deviceManager.deviceType;
 
   /// A printer-friendly name for this [type] of device.
   String get typeName => _deviceTypeName[type!] ?? 'pages.devices.type.unknown.name';
@@ -28,12 +28,12 @@ class DeviceViewModel extends ViewModel {
   Stream<DeviceStatus> get statusEvents => deviceManager.statusEvents;
 
   /// The device id
-  String get id => deviceManager.id;
+  String get id => deviceManager.displayName ?? '';
 
   /// A printer-friendly name for this device.
   String get name {
-    if (deviceManager is BTLEDeviceManager) {
-      return (deviceManager as BTLEDeviceManager).btleName;
+    if (deviceManager is BLEDeviceManager) {
+      return (deviceManager as BLEDeviceManager).bleName ?? '';
     } else if (deviceManager is PolarDeviceManager) {
       return (deviceManager as PolarDeviceManager).displayName ?? '';
     } else {
@@ -78,15 +78,15 @@ class DeviceViewModel extends ViewModel {
 
   PolarDeviceType get polarDeviceType {
     if (deviceManager is PolarDeviceManager) {
-      return (deviceManager as PolarDeviceManager).configuration?.deviceType ?? PolarDeviceType.UNKNOWN;
+      return (deviceManager as PolarDeviceManager).polarDeviceType ?? PolarDeviceType.Unknown;
     } else {
-      return PolarDeviceType.UNKNOWN;
+      return PolarDeviceType.Unknown;
     }
   }
 
   MovesenseDeviceType get movesenseDeviceType {
     if (deviceManager is MovesenseDeviceManager) {
-      return (deviceManager as MovesenseDeviceManager).configuration?.deviceType ?? MovesenseDeviceType.UNKNOWN;
+      return (deviceManager as MovesenseDeviceManager).movesenseDeviceType;
     } else {
       return MovesenseDeviceType.UNKNOWN;
     }
@@ -94,19 +94,18 @@ class DeviceViewModel extends ViewModel {
 
   /// Display information about this phone.
   Map<String, String?> get phoneInfo => {
-        'name': '${DeviceInfo().deviceID}',
-        'model': '${DeviceInfo().deviceModel} (${DeviceInfo().deviceManufacturer?.toUpperCase()})',
-        'version': 'SDK ${DeviceInfo().sdk}',
-      };
+    'name': '${DeviceInfoService().deviceID}',
+    'model': '${DeviceInfoService().deviceModel} (${DeviceInfoService().deviceManufacturer?.toUpperCase()})',
+    'version': 'SDK ${DeviceInfoService().sdk}',
+  };
 
   /// Map a selected device to the device in the protocol and connect to it.
   void connectToDevice(BluetoothDevice selectedDevice) {
-    if (deviceManager is BTLEDeviceManager) {
-      (deviceManager as BTLEDeviceManager).btleAddress = selectedDevice.remoteId.str;
-      (deviceManager as BTLEDeviceManager).btleName = selectedDevice.platformName;
+    if (deviceManager is BLEDeviceManager) {
+      (deviceManager as BLEDeviceManager).bleAddress = selectedDevice.remoteId.str;
+      (deviceManager as BLEDeviceManager).bleName = selectedDevice.platformName;
     }
 
-    Sensing().controller?.saveDeployment();
     deviceManager.connect();
   }
 
@@ -115,15 +114,13 @@ class DeviceViewModel extends ViewModel {
     try {
       await deviceManager.disconnect();
 
-      // Erase BTLE information so the user can connect to another device, if needed.
-      if (deviceManager is BTLEDeviceManager) {
-        (deviceManager as BTLEDeviceManager).btleAddress = '';
-        (deviceManager as BTLEDeviceManager).btleName = '';
+      // Erase BLE information so the user can connect to another device, if needed.
+      if (deviceManager is BLEDeviceManager) {
+        (deviceManager as BLEDeviceManager).bleAddress = '';
+        (deviceManager as BLEDeviceManager).bleName = '';
       }
-
-      Sensing().controller?.saveDeployment();
     } catch (error) {
-      warning("$runtimeType - Error disconnecting to device '${deviceManager.id}' - $error.");
+      warning("$runtimeType - Error disconnecting to device '${deviceManager.displayName}' - $error.");
     }
   }
 }
@@ -149,57 +146,30 @@ const Map<String, String> _deviceTypeDescription = {
 };
 
 const Map<String, Icon> _deviceTypeIcon = {
-  Smartphone.DEVICE_TYPE: Icon(
-    Icons.phone_android,
-    size: 30,
-    color: CACHET.GREEN_1,
-  ),
-  WeatherService.DEVICE_TYPE: Icon(
-    Icons.wb_cloudy,
-    color: CACHET.BLUE_1,
-  ),
-  AirQualityService.DEVICE_TYPE: Icon(
-    Icons.air,
-    color: CACHET.LIGHT_BLUE,
-  ),
-  LocationService.DEVICE_TYPE: Icon(
-    Icons.location_on,
-    color: CACHET.GREEN,
-  ),
-  PolarDevice.DEVICE_TYPE: Icon(
-    Icons.monitor_heart,
-    size: 30,
-    color: CACHET.RED,
-  ),
-  MovesenseDevice.DEVICE_TYPE: Icon(
-    Icons.circle,
-    size: 30,
-    color: CACHET.GREY_1,
-  ),
-  HealthService.DEVICE_TYPE: Icon(
-    Icons.favorite_rounded,
-    size: 30,
-    color: CACHET.RED_1,
-  ),
+  Smartphone.DEVICE_TYPE: Icon(Icons.phone_android, size: 30, color: CACHET.GREEN_1),
+  WeatherService.DEVICE_TYPE: Icon(Icons.wb_cloudy, color: CACHET.BLUE_1),
+  AirQualityService.DEVICE_TYPE: Icon(Icons.air, color: CACHET.LIGHT_BLUE),
+  LocationService.DEVICE_TYPE: Icon(Icons.location_on, color: CACHET.GREEN),
+  PolarDevice.DEVICE_TYPE: Icon(Icons.monitor_heart, size: 30, color: CACHET.RED),
+  MovesenseDevice.DEVICE_TYPE: Icon(Icons.circle, size: 30, color: CACHET.GREY_1),
+  HealthService.DEVICE_TYPE: Icon(Icons.favorite_rounded, size: 30, color: CACHET.RED_1),
 };
 
 const Map<DeviceStatus, dynamic> _deviceStatusIcon = {
-  DeviceStatus.initialized: "pages.devices.status.action.connect",
+  DeviceStatus.configured: "pages.devices.status.action.connect",
   DeviceStatus.connecting: Icon(Icons.bluetooth_searching_rounded, color: CACHET.DARK_BLUE, size: 30),
   DeviceStatus.connected: Icon(Icons.bluetooth_rounded, color: CACHET.GREEN_1, size: 30),
   DeviceStatus.disconnected: "pages.devices.status.action.connect",
   DeviceStatus.paired: "pages.devices.status.action.connect",
-  DeviceStatus.error: Icon(Icons.error_outline, color: CACHET.RED_1, size: 30),
   DeviceStatus.unknown: Icon(Icons.error_outline, color: CACHET.RED_1, size: 30),
 };
 
 const Map<DeviceStatus, dynamic> _serviceStatusIcon = {
-  DeviceStatus.initialized: "pages.devices.status.action.connect",
+  DeviceStatus.configured: "pages.devices.status.action.connect",
   DeviceStatus.connecting: Icon(Icons.sensors_off_rounded, color: CACHET.GREEN_1, size: 30),
   DeviceStatus.connected: Icon(Icons.sensors_rounded, color: CACHET.GREEN_1, size: 30),
   DeviceStatus.disconnected: "pages.devices.status.action.connect",
   DeviceStatus.paired: "pages.devices.status.action.connect",
-  DeviceStatus.error: Icon(Icons.error_outline, color: CACHET.RED_1, size: 30),
   DeviceStatus.unknown: Icon(Icons.error_outline, color: CACHET.RED_1, size: 30),
 };
 
@@ -208,8 +178,7 @@ const Map<DeviceStatus, String> _deviceStatusText = {
   DeviceStatus.connected: "pages.devices.status.connected",
   DeviceStatus.disconnected: "pages.devices.status.disconnected",
   DeviceStatus.paired: "pages.devices.status.paired",
-  DeviceStatus.error: "pages.devices.status.error",
-  DeviceStatus.initialized: "pages.devices.status.initialized",
+  DeviceStatus.configured: "pages.devices.status.initialized",
   DeviceStatus.unknown: "pages.devices.status.unknown",
 };
 

--- a/lib/view_models/informed_consent_page_model.dart
+++ b/lib/view_models/informed_consent_page_model.dart
@@ -24,8 +24,6 @@ class InformedConsentViewModel extends ViewModel {
   /// Called when the informed consent has been accepted by the user.
   /// Returns once the upload to the backend has completed, so callers can
   /// safely route to a page whose redirect re-queries the backend.
-  Future<void> informedConsentHasBeenAccepted(
-    RPTaskResult informedConsentResult,
-  ) =>
+  Future<void> informedConsentHasBeenAccepted(RPTaskResult informedConsentResult) =>
       bloc.informedConsentHasBeenAccepted(informedConsentResult);
 }

--- a/lib/view_models/profile_page_model.dart
+++ b/lib/view_models/profile_page_model.dart
@@ -1,7 +1,7 @@
 part of carp_study_app;
 
 class ProfilePageViewModel extends ViewModel {
-  String get userId => bloc.user?.id ?? bloc.deployment?.participantId ?? '';
+  String get userId => bloc.user?.id ?? bloc.study?.participantId ?? '';
   String get username => bloc.user?.username ?? '';
   String get firstName => bloc.user?.firstName ?? '';
   String get lastName => bloc.user?.lastName ?? '';
@@ -11,15 +11,15 @@ class ProfilePageViewModel extends ViewModel {
   String get studyId => bloc.deployment?.studyId ?? '';
   String get studyDeploymentId => bloc.deployment?.studyDeploymentId ?? '';
   String get studyDeploymentTitle => bloc.deployment?.studyDescription?.title ?? '';
-  String get participantId => bloc.deployment?.participantId ?? '';
-  String get participantRole => bloc.deployment?.participantRoleName ?? '';
+  String get participantId => bloc.study?.participantId ?? '';
+  String get participantRole => bloc.study?.participantRoleName ?? '';
   String get deviceRole => bloc.deployment?.deviceRoleName ?? '';
 
   String get responsibleEmail => bloc.deployment?.studyDescription?.responsible?.email ?? 'study@carp.dk';
   String get privacyPolicyUrl =>
       bloc.deployment?.studyDescription?.privacyPolicyUrl ?? 'https://carp.dk/privacy-policy-app/';
   String get studyDescriptionUrl => bloc.deployment?.studyDescription?.studyDescriptionUrl ?? '';
-  String get deviceID => DeviceInfo().deviceID ?? '';
+  String get deviceID => DeviceInfoService().deviceID ?? '';
   String get currentServer => bloc.backend.uri.toString();
 
   ProfilePageViewModel();

--- a/lib/view_models/study_page_model.dart
+++ b/lib/view_models/study_page_model.dart
@@ -7,7 +7,7 @@ class StudyPageViewModel extends ViewModel {
   String get description => bloc.deployment?.studyDescription?.description ?? '';
   String get purpose => bloc.deployment?.studyDescription?.purpose ?? '';
   Image get image => Image.asset('assets/images/exercise.png');
-  String? get userID => bloc.deployment?.participantId;
+  String? get userID => bloc.study?.participantId;
   String get studyDeploymentId => bloc.deployment?.studyDeploymentId ?? '';
   String get responsibleName => bloc.deployment?.studyDescription?.responsible?.name ?? '';
   String get responsibleEmail => bloc.deployment?.studyDescription?.responsible?.email ?? '';
@@ -22,7 +22,7 @@ class StudyPageViewModel extends ViewModel {
   String get piAffiliation =>
       bloc.deployment?.responsible?.affiliation ?? 'Department of Health Technology, Technical University of Denmark';
 
-  String get participantRole => bloc.deployment?.participantRoleName ?? '';
+  String get participantRole => bloc.study?.participantRoleName ?? '';
   String get deviceRole => bloc.deployment?.deviceRoleName ?? '';
 
   Future<StudyDeploymentStatus?> get studyDeploymentStatus => bloc.studyDeploymentStatus;
@@ -51,11 +51,11 @@ class StudyPageViewModel extends ViewModel {
 
   static const dummyID = '00000000-0000-0000-0000-000000000000';
   Message get studyDescriptionMessage => Message(
-        id: dummyID,
-        title: title,
-        message: description,
-        type: MessageType.announcement,
-        timestamp: bloc.studyStartTimestamp ?? DateTime.now(),
-        image: 'assets/images/kids.png',
-      );
+    id: dummyID,
+    title: title,
+    message: description,
+    type: MessageType.announcement,
+    timestamp: bloc.studyStartTimestamp ?? DateTime.now(),
+    image: 'assets/images/kids.png',
+  );
 }

--- a/lib/view_models/user_tasks.dart
+++ b/lib/view_models/user_tasks.dart
@@ -3,19 +3,15 @@ part of carp_study_app;
 /// A [UserTaskFactory] that can handle the user tasks in this app.
 class AppUserTaskFactory implements UserTaskFactory {
   @override
-  List<String> types = [
-    SurveyUserTask.AUDIO_TYPE,
-    SurveyUserTask.VIDEO_TYPE,
-    SurveyUserTask.IMAGE_TYPE,
-  ];
+  List<String> types = [AppTask.AUDIO_TYPE, AppTask.VIDEO_TYPE, AppTask.IMAGE_TYPE];
 
   @override
   UserTask create(AppTaskExecutor executor) => switch (executor.task.type) {
-        SurveyUserTask.AUDIO_TYPE => AudioUserTask(executor),
-        SurveyUserTask.VIDEO_TYPE => VideoUserTask(executor),
-        SurveyUserTask.IMAGE_TYPE => VideoUserTask(executor),
-        _ => BackgroundSensingUserTask(executor),
-      };
+    AppTask.AUDIO_TYPE => AudioUserTask(executor),
+    AppTask.VIDEO_TYPE => VideoUserTask(executor),
+    AppTask.IMAGE_TYPE => VideoUserTask(executor),
+    _ => BackgroundSensingUserTask(executor),
+  };
 }
 
 /// A user task handling audio recordings.
@@ -50,7 +46,7 @@ class AudioUserTask extends UserTask {
     _countDownController = StreamController.broadcast();
     ongoingRecordingDuration = recordingDuration;
     state = UserTaskState.started;
-    backgroundTaskExecutor.start();
+    backgroundTaskExecutor.resume();
 
     try {
       backgroundTaskExecutor.measurements
@@ -72,7 +68,7 @@ class AudioUserTask extends UserTask {
   void onRecordStop() {
     _timer?.cancel();
     _countDownController?.close();
-    backgroundTaskExecutor.stop();
+    backgroundTaskExecutor.pause();
   }
 
   /// Callback when recording is to start.
@@ -81,7 +77,7 @@ class AudioUserTask extends UserTask {
     _timer?.cancel();
     _countDownController?.close();
 
-    backgroundTaskExecutor.stop();
+    backgroundTaskExecutor.pause();
   }
 }
 
@@ -108,14 +104,14 @@ class VideoUserTask extends UserTask {
     _startRecordingTime = DateTime.now();
     _endRecordingTime = DateTime.now();
 
-    backgroundTaskExecutor.start();
+    backgroundTaskExecutor.resume();
   }
 
   /// Callback when video recording is started.
   void onRecordStart() {
     debug('$runtimeType - onRecordStart()');
     _startRecordingTime = DateTime.now();
-    backgroundTaskExecutor.start();
+    backgroundTaskExecutor.resume();
   }
 
   /// Callback when video recording is stopped.
@@ -130,18 +126,26 @@ class VideoUserTask extends UserTask {
   /// the data stream.
   void onSave() {
     MediaData? media;
-    backgroundTaskExecutor.stop();
+    backgroundTaskExecutor.pause();
     if (_file != null) {
       // create the media measurement ...
       media = switch (_mediaType) {
-        MediaType.image => ImageMedia(
-            filename: _file!.path, startRecordingTime: _startRecordingTime!, endRecordingTime: _endRecordingTime)
-          ..filename = _file!.path.split("/").last
-          ..path = _file!.path,
-        MediaType.video => VideoMedia(
-            filename: _file!.path, startRecordingTime: _startRecordingTime!, endRecordingTime: _endRecordingTime)
-          ..filename = _file!.path.split("/").last
-          ..path = _file!.path,
+        MediaType.image =>
+          ImageMedia(
+              filename: _file!.path,
+              startRecordingTime: _startRecordingTime!,
+              endRecordingTime: _endRecordingTime,
+            )
+            ..filename = _file!.path.split("/").last
+            ..path = _file!.path,
+        MediaType.video =>
+          VideoMedia(
+              filename: _file!.path,
+              startRecordingTime: _startRecordingTime!,
+              endRecordingTime: _endRecordingTime,
+            )
+            ..filename = _file!.path.split("/").last
+            ..path = _file!.path,
         _ => null,
       };
 

--- a/lib/view_models/view_model.dart
+++ b/lib/view_models/view_model.dart
@@ -5,13 +5,13 @@ part of carp_study_app;
 /// Note that a view model is a [ChangeNotifier] and will notify its listeners
 /// if changed, including any [ListenableBuilder] widgets.
 abstract class ViewModel extends ChangeNotifier {
-  SmartphoneDeploymentController? _controller;
+  SmartphoneStudyController? _controller;
 
-  SmartphoneDeploymentController? get controller => _controller;
+  SmartphoneStudyController? get controller => _controller;
 
   /// Initialize this view model before use.
   @mustCallSuper
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     _controller = ctrl;
   }
 
@@ -65,7 +65,7 @@ abstract class SerializableViewModel<D extends DataModel> extends ViewModel {
 
   @override
   @mustCallSuper
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
     _model = createModel();
 
@@ -208,7 +208,7 @@ class CarpStudyAppViewModel extends ViewModel {
   ParticipantDataPageViewModel get participantDataPageViewModel => _participantDataPageViewModel;
 
   @override
-  void init(SmartphoneDeploymentController ctrl) {
+  void init(SmartphoneStudyController ctrl) {
     super.init(ctrl);
     _taskListPageViewModel.init(ctrl);
     _studyPageViewModel.init(ctrl);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: app_version_update
-      sha256: "9277bd6539b4ced74fbcabd5d6aba47b183b2f0ebc56e1d2689be0e6025ab458"
+      sha256: a7f351142be6d2ae1c504041e4c875a69dd1a97349b5a34ab16cdf20ac4d4810
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.3"
+    version: "6.2.0"
   appcheck:
     dependency: "direct main"
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: audio_streamer
-      sha256: "77b4271058fb9273d51e59a47729c6c02d046adcae1c93bc71af26822705b2ab"
+      sha256: aed4bc55f57d65953b16344f5848239e1c9bd058cf5a6c23d7b4173f337d4ea8
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.0"
   audioplayers:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: battery_plus
-      sha256: "03d5a6bb36db9d2b977c548f6b0262d5a84c4d5a4cfee2edac4a91d57011b365"
+      sha256: ad16fcb55b7384be6b4bbc763d5e2031ac7ea62b2d9b6b661490c7b9741155bf
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.3"
+    version: "7.0.0"
   battery_plus_platform_interface:
     dependency: transitive
     description:
@@ -277,74 +277,74 @@ packages:
     dependency: "direct main"
     description:
       name: carp_audio_package
-      sha256: cdcc18d011c34b1e29ada818596e6b628669705609a490c3d71d704b18e4cc9e
+      sha256: f309c570207cc14a7dc22dfcf5eeef5d3bddef2147cc1bf77256af8e696f6007
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.3"
+    version: "2.0.0"
   carp_backend:
     dependency: "direct main"
     description:
       name: carp_backend
-      sha256: f92462c41a38cf85cf0b5f602126b123f60a96dcccfda3d2751dcdf0b650feec
+      sha256: f5998fd5cf14b54e5c159d6f3e18ad2b63c3b97d3062a592d311425dc45dcf4b
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "2.0.0"
   carp_connectivity_package:
     dependency: "direct main"
     description:
       name: carp_connectivity_package
-      sha256: "3a65729dadeead390071f5e54faf017c5d2977f492d1e709e3a501ffdb8b4951"
+      sha256: a23dfbe0ed987439a3af3d5228bf68d63c2b68a9e10f496561a8501736b36065
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "2.0.0"
   carp_context_package:
     dependency: "direct main"
     description:
       name: carp_context_package
-      sha256: a1a708be991d8e7a66e43b43ad606c2915ac9c55851f5c57f63a61f35baefb6e
+      sha256: "3a4d697c0632164667598bc4a08ecbabd16e8fba26294cbb04ff2dad13625ca5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "2.0.0"
   carp_core:
     dependency: "direct main"
     description:
       name: carp_core
-      sha256: "1fcac456368fc32ec9738834b5e0e59132985cb6bf0d8157bbe8d8914ecb6fb2"
+      sha256: "2644ff9bacd05de0b8290e3abd74542c98380ee9c361e83be9ded86b9cb3ed7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.4"
+    version: "2.1.2"
   carp_health_package:
     dependency: "direct main"
     description:
       name: carp_health_package
-      sha256: db2ff8fdc4acd7fcbfc240fb4a53a7e0557766f188e4b0fc44a375ceebf50743
+      sha256: "0cf14b9813058c9ce8e1654da3d9dc6af5f0a4a512f6c1a08a939f764f234999"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   carp_mobile_sensing:
     dependency: "direct main"
     description:
       name: carp_mobile_sensing
-      sha256: c9b58ba07c7468a681619aad4ff87c7382b453538994a974bce63b87bd9959cc
+      sha256: "715e2dda7db3cab8c966975b1ab69d755dee15076712b865f164955674d89456"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "2.1.1"
   carp_movesense_package:
     dependency: "direct main"
     description:
       name: carp_movesense_package
-      sha256: e17094a42fae084d26c7759459493389016d9efc9f1555c7a5044eec1469d87d
+      sha256: fc18d9a4c0585490dab47cb707a46a7b35c64f1d3f8fde25f8cca74b09058991
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.6"
+    version: "2.0.0"
   carp_polar_package:
     dependency: "direct main"
     description:
       name: carp_polar_package
-      sha256: "21446b411ffc3bcb34f93be33552e5a98cba59a162b2228d92fbdc21ffd7857a"
+      sha256: d8eeae5b729da833914f2a6cdbd38cca5e5557b71e24d3d7640630b323e07de4
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "2.0.0"
   carp_serializable:
     dependency: "direct main"
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_survey_package
-      sha256: "25c055e2267ace486beff4e31bf13eab7d6806f413a54020f74297b6d62fe6b7"
+      sha256: "5b20d8ccae6af04df6b7c77b8c0e5cf7aef2411f830d830329ba96651d75bae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "2.0.0"
   carp_themes_package:
     dependency: "direct main"
     description:
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_webservices
-      sha256: "6459af381237f38e65e6300763cddc04186c69e746ab97210f8134426e8a17dc"
+      sha256: "24e07669a9ff2f6886be2c34d5d331e3e7e8a8a71a640ec3d605a7d6439a9c59"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "4.1.0"
   characters:
     dependency: transitive
     description:
@@ -453,10 +453,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -581,10 +581,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "11.5.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -702,6 +702,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.0.0"
+  flutter_background:
+    dependency: transitive
+    description:
+      name: flutter_background
+      sha256: ee47be26beddc59875158a93eeaaad0c0b5f3b21afbdad3de73a2903be824f0e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   flutter_blue_plus:
     dependency: "direct main"
     description:
@@ -762,34 +770,34 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "11.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -892,10 +900,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_timezone
-      sha256: "13b2109ad75651faced4831bf262e32559e44aa549426eab8a597610d385d934"
+      sha256: "869677426fde92dbe170fb7d2d4929f2a8343c2f5f62f08b0bb64f908630b073"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "5.1.0"
   flutter_web_auth_2:
     dependency: transitive
     description:
@@ -969,10 +977,10 @@ packages:
     dependency: transitive
     description:
       name: health
-      sha256: "0432c4e5c5348164adff57e78ca3191c88f0cdf7c2b0d72b6785a6af965177ac"
+      sha256: "2d9e119f3a1d281139f93149b41032b9f80b759960875bc784c5a25dd3c17524"
       url: "https://pub.dev"
     source: hosted
-    version: "12.2.1"
+    version: "13.3.1"
   hooks:
     dependency: transitive
     description:
@@ -993,10 +1001,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -1169,10 +1177,10 @@ packages:
     dependency: transitive
     description:
       name: light
-      sha256: cb6551bf3ac336fcd5d0ce85ba3345a6f195785bb913f7541a976b4367aeb3a3
+      sha256: e1f9b09222881390203a3f31ab2a19e1375e067840018bbdb49a8716e849bdcb
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0"
   lints:
     dependency: transitive
     description:
@@ -1273,10 +1281,10 @@ packages:
     dependency: transitive
     description:
       name: mobility_features
-      sha256: "6c2f522f2fb6891234f65b0fd0743824567d90110beb461933cdd1cf5f69f0ba"
+      sha256: "102728cbd718451a462ad2ea28b5f0735b1920eafc6a00148fc3fa3195daea4b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -1289,10 +1297,10 @@ packages:
     dependency: transitive
     description:
       name: network_info_plus
-      sha256: f926b2ba86aa0086a0dfbb9e5072089bc213d854135c1712f1d29fc89ba3c877
+      sha256: "2866dadcbee2709e20d67737a1556f5675b8b0cdcf2c1659ba74bc21bffede4f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   network_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1481,10 +1489,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1569,18 +1577,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.0.1"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1649,10 +1657,10 @@ packages:
     dependency: transitive
     description:
       name: polar
-      sha256: "703e13b2c0646d2327c3ef7e83ed09ed5f01f6de14d8813d9b62951db1f1357f"
+      sha256: f0c168159a57f12863981d1dba14dc3622582f54ef0ce9658c377804997dc7c7
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "7.10.0"
   pool:
     dependency: transitive
     description:
@@ -1761,18 +1769,18 @@ packages:
     dependency: transitive
     description:
       name: screen_state
-      sha256: de85988dc39f03ab1a8bdadfdd4b0592d71842c161b065a6660dad62d4e42385
+      sha256: "64a4583456f9fa91a8d4c681864384513b65590b0bc18fbc4b74c519c4b66c75"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "5.0.0"
   sensors_plus:
     dependency: transitive
     description:
       name: sensors_plus
-      sha256: "89e2bfc3d883743539ce5774a2b93df61effde40ff958ecad78cd66b1a8b8d52"
+      sha256: "56e8cd4260d9ed8e00ecd8da5d9fdc8a1b2ec12345a750dfa51ff83fcf12e3fa"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.0"
   sensors_plus_platform_interface:
     dependency: transitive
     description:
@@ -1990,10 +1998,10 @@ packages:
     dependency: transitive
     description:
       name: stats
-      sha256: "35dba13a465ac4f788d2f21211bb4736902f49ef02471ba39337d56c4644290c"
+      sha256: f08a0b8dcf95cc68960e85eaa21c80e8837fb816c719a99a0edd36c44831d403
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -2078,10 +2086,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1753,10 +1753,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.28.0"
+    version: "0.27.7"
   sample_statistics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,30 +73,30 @@ dependency_overrides:
   #   path: ../carp.sensing-flutter/carp_mobile_sensing/
   # carp_context_package:
   #   path: ../carp.sensing-flutter/packages/carp_context_package/
-  # carp_connectivity_package:
-  #   path: ../../packages/carp_connectivity_package/
-  # carp_survey_package:
-  #   path: ../carp/carp.sensing-flutter/packages/carp_survey_package/
-  # carp_communication_package:
-  #   path: ../../packages/carp_communication_package/
-  # carp_audio_package:
-  #   path: ../carp/carp.sensing-flutter/packages/carp_audio_package/
-  # carp_apps_package:
-  #   path: ../../packages/carp_apps_package/
   # carp_esense_package:
-  #   path: ../../packages/carp_esense_package/
-  # carp_polar_package:
-  #   path: ../carp/carp.sensing-flutter/packages/carp_polar_package/
-  # carp_movisens_package:
-  #   path: ../../packages/carp_movisens_package/
+  #   path: ../carp.sensing-flutter/packages/carp_esense_package/
   # carp_health_package:
-  #   path: ../carp/carp.sensing-flutter/packages/carp_health_package/
+  #   path: ../carp.sensing-flutter/packages/carp_health_package/
+  # carp_polar_package:
+  #   path: ../carp.sensing-flutter/packages/carp_polar_package/
+  # carp_movisens_package:
+  #   path: ../carp.sensing-flutter/packages/carp_movisens_package/
   # carp_movesense_package:
-  #   path: ../carp/carp.sensing-flutter/packages/carp_movesense_package/
+  #   path: ../carp.sensing-flutter/packages/carp_movesense_package/
+  # carp_connectivity_package:
+  #   path: ../carp.sensing-flutter/packages/carp_connectivity_package/
+  # carp_survey_package:
+  #   path: ../carp.sensing-flutter/packages/carp_survey_package/
+  # carp_communication_package:
+  #   path: ../carp.sensing-flutter/packages/carp_communication_package/
+  # carp_audio_package:
+  #   path: ../carp.sensing-flutter/packages/carp_audio_package/
+  # carp_apps_package:
+  #   path: ../carp.sensing-flutter/packages/carp_apps_package/
   # carp_webservices:
   #   path: ../carp.sensing-flutter/backends/carp_webservices/
   # carp_backend:
-  #   path: ../carp/carp.sensing-flutter/backends/carp_backend/
+  #   path: ../carp.sensing-flutter/backends/carp_backend/
   # research_package:
   #   path: ../research.package/
   # cognition_package:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,30 +4,30 @@ publish_to: "none"
 version: 4.3.0+1
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  carp_serializable: ^2.0.0
-  carp_core: ^1.9.0
-  carp_mobile_sensing: ^1.13.0
-  carp_context_package: ^1.10.0
-  carp_connectivity_package: ^1.7.0
-  carp_survey_package: ^1.8.2
-  carp_audio_package: ^1.10.0
-  carp_polar_package: ^1.6.1
-  carp_health_package: ^3.2.0
-  carp_movesense_package: ^1.7.2
+  carp_serializable: ^2.0.1
+  carp_core: ^2.1.2
+  carp_mobile_sensing: ^2.1.1
+  carp_context_package: ^2.0.0
+  carp_connectivity_package: ^2.0.0
+  carp_survey_package: ^2.0.0
+  carp_audio_package: ^2.0.0
+  carp_polar_package: ^2.0.0
+  carp_health_package: ^4.0.0
+  carp_movesense_package: ^2.0.0
   carp_themes_package: ^0.0.5
 
-  carp_webservices: ^3.8.0
-  carp_backend: ^1.9.2
+  carp_webservices: ^4.0.0
+  carp_backend: ^2.0.0
 
   research_package: ^2.2.0
-  cognition_package: ^1.6.1
+  cognition_package: ^1.7.0
 
   url_launcher: ^6.1.5
   timeago: ^3.1.0
@@ -46,8 +46,8 @@ dependencies:
   go_router: ^15.0.0
   flutter_svg: ^2.0.4
   flutter_blue_plus: ^1.15.5
-  permission_handler: ^11.0.1
-  connectivity_plus: ^6.0.0
+  permission_handler: ^12.0.3
+  connectivity_plus: ^7.0.0
   open_settings_plus: ^0.4.0
   appcheck: ^1.5.2
   flutter_plugin_android_lifecycle: ^2.0.24
@@ -119,6 +119,13 @@ dev_dependencies:
 #  3. run 'dart run flutter_launcher_icons:main'
 
 flutter:
+  # Route all iOS native deps through CocoaPods. The Polar BLE SDK (via the
+  # `polar` plugin) and Movesense (`mdsflutter`, CocoaPods-only) both pull in
+  # SwiftProtobuf; with Swift Package Manager enabled Polar resolves it via SPM
+  # while Movesense uses CocoaPods, producing duplicate-symbol link errors.
+  config:
+    enable-swift-package-manager: false
+
   uses-material-design: true
 
   assets:

--- a/test/exports.dart
+++ b/test/exports.dart
@@ -6,6 +6,6 @@ export 'package:mockito/mockito.dart';
 export 'package:mockito/annotations.dart';
 export 'package:carp_mobile_sensing/carp_mobile_sensing.dart';
 export 'package:carp_polar_package/carp_polar_package.dart';
-export 'package:carp_core/carp_core.dart';
+export 'package:carp_core/carp_core.dart' hide Smartphone, BLEHeartRateDevice;
 
 export 'heart_rate_data_model_test.mocks.dart';

--- a/test/heart_rate_data_model_test.dart
+++ b/test/heart_rate_data_model_test.dart
@@ -1,7 +1,7 @@
 import 'exports.dart';
 
 @GenerateNiceMocks([
-  MockSpec<SmartphoneDeploymentController>(),
+  MockSpec<SmartphoneStudyController>(),
   MockSpec<HeartRateCardViewModel>(),
   MockSpec<HourlyHeartRate>(),
   MockSpec<PolarHRSample>(),
@@ -13,7 +13,7 @@ void main() {
   setUp(() {});
   group("HeartRateCardViewModel", () {
     test('initializes HeartRateCardViewModel', skip: true, () {
-      final controller = MockSmartphoneDeploymentController();
+      final controller = MockSmartphoneStudyController();
       final model = MockHeartRateCardViewModel();
       final dataModel = MockHourlyHeartRate();
       when(model.createModel()).thenReturn(dataModel);
@@ -25,7 +25,7 @@ void main() {
     });
     group('init', () {
       group('should listen to heart rate events', () {
-        final mockSmartphoneDeploymentController = MockSmartphoneDeploymentController();
+        final mockSmartphoneStudyController = MockSmartphoneStudyController();
         final mockPolarHRSample = MockPolarHRSample();
         final mockPolarHRDatum = MockPolarHR();
         final mockMeasurement = MockMeasurement();
@@ -33,9 +33,9 @@ void main() {
         final heartRateStreamController = StreamController<MockMeasurement>.broadcast();
 
         setUp(() {
-          when(mockSmartphoneDeploymentController.measurements).thenAnswer((_) => heartRateStreamController.stream);
+          when(mockSmartphoneStudyController.measurements).thenAnswer((_) => heartRateStreamController.stream);
 
-          viewModel.init(mockSmartphoneDeploymentController);
+          viewModel.init(mockSmartphoneStudyController);
         });
         tearDownAll(() {
           heartRateStreamController.close();
@@ -52,8 +52,10 @@ void main() {
             await Future<void>.delayed(const Duration(milliseconds: 100));
             expect(viewModel.currentHeartRate, equals(80.0));
             expect(viewModel.dayMinMax, equals(HeartRateMinMaxPrHour(80, 80)));
-            expect(viewModel.hourlyHeartRate,
-                equals((HourlyHeartRate().addHeartRate(DateTime.now().hour, 80)).hourlyHeartRate));
+            expect(
+              viewModel.hourlyHeartRate,
+              equals((HourlyHeartRate().addHeartRate(DateTime.now().hour, 80)).hourlyHeartRate),
+            );
           });
           test('with multiple events', () async {
             // Add a heart rate data point to the stream
@@ -74,9 +76,12 @@ void main() {
             expect(viewModel.currentHeartRate, equals(60));
             expect(viewModel.dayMinMax, equals(HeartRateMinMaxPrHour(60, 90)));
             expect(
-                viewModel.hourlyHeartRate,
-                equals((HourlyHeartRate().addHeartRate(DateTime.now().hour, 60).addHeartRate(DateTime.now().hour, 90))
-                    .hourlyHeartRate));
+              viewModel.hourlyHeartRate,
+              equals(
+                (HourlyHeartRate().addHeartRate(DateTime.now().hour, 60).addHeartRate(DateTime.now().hour, 90))
+                    .hourlyHeartRate,
+              ),
+            );
           });
           test('with events with data that is 0', () async {
             // Add a heart rate data point to the stream

--- a/test/heart_rate_data_model_test.mocks.dart
+++ b/test/heart_rate_data_model_test.mocks.dart
@@ -6,10 +6,10 @@
 import 'dart:async' as _i7;
 import 'dart:ui' as _i8;
 
-import 'package:carp_core/carp_core.dart' as _i3;
+import 'package:carp_core/carp_core.dart' as _i4;
 import 'package:carp_mobile_sensing/carp_mobile_sensing.dart' as _i2;
 import 'package:carp_polar_package/carp_polar_package.dart' as _i9;
-import 'package:carp_study_app/main.dart' as _i4;
+import 'package:carp_study_app/main.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i6;
 import 'package:permission_handler/permission_handler.dart' as _i5;
@@ -27,799 +27,347 @@ import 'package:permission_handler/permission_handler.dart' as _i5;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
-class _FakeDeviceController_0 extends _i1.SmartFake implements _i2.DeviceController {
-  _FakeDeviceController_0(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeSmartphoneStudy_0 extends _i1.SmartFake implements _i2.SmartphoneStudy {
+  _FakeSmartphoneStudy_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeSmartphoneDeploymentExecutor_1 extends _i1.SmartFake implements _i2.SmartphoneDeploymentExecutor {
-  _FakeSmartphoneDeploymentExecutor_1(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+  _FakeSmartphoneDeploymentExecutor_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeData_2 extends _i1.SmartFake implements _i3.Data {
-  _FakeData_2(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeHeartRateMinMaxPrHour_2 extends _i1.SmartFake implements _i3.HeartRateMinMaxPrHour {
+  _FakeHeartRateMinMaxPrHour_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeDeploymentService_3 extends _i1.SmartFake implements _i3.DeploymentService {
-  _FakeDeploymentService_3(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeHourlyHeartRate_3 extends _i1.SmartFake implements _i3.HourlyHeartRate {
+  _FakeHourlyHeartRate_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeHeartRateMinMaxPrHour_4 extends _i1.SmartFake implements _i4.HeartRateMinMaxPrHour {
-  _FakeHeartRateMinMaxPrHour_4(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeDateTime_4 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeHourlyHeartRate_5 extends _i1.SmartFake implements _i4.HourlyHeartRate {
-  _FakeHourlyHeartRate_5(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeDataType_5 extends _i1.SmartFake implements _i4.DataType {
+  _FakeDataType_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeDateTime_6 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_6(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeData_6 extends _i1.SmartFake implements _i4.Data {
+  _FakeData_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeDataType_7 extends _i1.SmartFake implements _i3.DataType {
-  _FakeDataType_7(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+class _FakeDataModel_7 extends _i1.SmartFake implements _i3.DataModel {
+  _FakeDataModel_7(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeDataModel_8 extends _i1.SmartFake implements _i4.DataModel {
-  _FakeDataModel_8(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-/// A class which mocks [SmartphoneDeploymentController].
+/// A class which mocks [SmartphoneStudyController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSmartphoneDeploymentController extends _i1.Mock implements _i2.SmartphoneDeploymentController {
+class MockSmartphoneStudyController extends _i1.Mock implements _i2.SmartphoneStudyController {
   @override
-  _i2.DeviceController get deviceRegistry => (super.noSuchMethod(
-        Invocation.getter(#deviceRegistry),
-        returnValue: _FakeDeviceController_0(
-          this,
-          Invocation.getter(#deviceRegistry),
-        ),
-        returnValueForMissingStub: _FakeDeviceController_0(
-          this,
-          Invocation.getter(#deviceRegistry),
-        ),
-      ) as _i2.DeviceController);
-
-  @override
-  Map<_i5.Permission, _i5.PermissionStatus> get permissions => (super.noSuchMethod(
-        Invocation.getter(#permissions),
-        returnValue: <_i5.Permission, _i5.PermissionStatus>{},
-        returnValueForMissingStub: <_i5.Permission, _i5.PermissionStatus>{},
-      ) as Map<_i5.Permission, _i5.PermissionStatus>);
-
-  @override
-  _i2.SmartphoneDeploymentExecutor get executor => (super.noSuchMethod(
-        Invocation.getter(#executor),
-        returnValue: _FakeSmartphoneDeploymentExecutor_1(
-          this,
-          Invocation.getter(#executor),
-        ),
-        returnValueForMissingStub: _FakeSmartphoneDeploymentExecutor_1(
-          this,
-          Invocation.getter(#executor),
-        ),
-      ) as _i2.SmartphoneDeploymentExecutor);
-
-  @override
-  String get privacySchemaName => (super.noSuchMethod(
-        Invocation.getter(#privacySchemaName),
-        returnValue: _i6.dummyValue<String>(
-          this,
-          Invocation.getter(#privacySchemaName),
-        ),
-        returnValueForMissingStub: _i6.dummyValue<String>(
-          this,
-          Invocation.getter(#privacySchemaName),
-        ),
-      ) as String);
-
-  @override
-  _i2.DataTransformer get transformer => (super.noSuchMethod(
-        Invocation.getter(#transformer),
-        returnValue: (_i3.Data __p0) => _FakeData_2(
-          this,
-          Invocation.getter(#transformer),
-        ),
-        returnValueForMissingStub: (_i3.Data __p0) => _FakeData_2(
-          this,
-          Invocation.getter(#transformer),
-        ),
-      ) as _i2.DataTransformer);
-
-  @override
-  _i7.Stream<_i3.Measurement> get measurements => (super.noSuchMethod(
-        Invocation.getter(#measurements),
-        returnValue: _i7.Stream<_i3.Measurement>.empty(),
-        returnValueForMissingStub: _i7.Stream<_i3.Measurement>.empty(),
-      ) as _i7.Stream<_i3.Measurement>);
-
-  @override
-  int get samplingSize => (super.noSuchMethod(
-        Invocation.getter(#samplingSize),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
-
-  @override
-  _i3.DeploymentService get deploymentService => (super.noSuchMethod(
-        Invocation.getter(#deploymentService),
-        returnValue: _FakeDeploymentService_3(
-          this,
-          Invocation.getter(#deploymentService),
-        ),
-        returnValueForMissingStub: _FakeDeploymentService_3(
-          this,
-          Invocation.getter(#deploymentService),
-        ),
-      ) as _i3.DeploymentService);
-
-  @override
-  _i7.Stream<_i3.StudyStatus> get statusEvents => (super.noSuchMethod(
-        Invocation.getter(#statusEvents),
-        returnValue: _i7.Stream<_i3.StudyStatus>.empty(),
-        returnValueForMissingStub: _i7.Stream<_i3.StudyStatus>.empty(),
-      ) as _i7.Stream<_i3.StudyStatus>);
-
-  @override
-  _i3.StudyStatus get status => (super.noSuchMethod(
-        Invocation.getter(#status),
-        returnValue: _i3.StudyStatus.DeploymentNotStarted,
-        returnValueForMissingStub: _i3.StudyStatus.DeploymentNotStarted,
-      ) as _i3.StudyStatus);
-
-  @override
-  bool get isInitialized => (super.noSuchMethod(
-        Invocation.getter(#isInitialized),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  bool get isDeployed => (super.noSuchMethod(
-        Invocation.getter(#isDeployed),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  bool get isStopped => (super.noSuchMethod(
-        Invocation.getter(#isStopped),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  List<_i3.DeviceConfiguration<_i3.DeviceRegistration>> get remainingDevicesToRegister => (super.noSuchMethod(
-        Invocation.getter(#remainingDevicesToRegister),
-        returnValue: <_i3.DeviceConfiguration<_i3.DeviceRegistration>>[],
-        returnValueForMissingStub: <_i3.DeviceConfiguration<_i3.DeviceRegistration>>[],
-      ) as List<_i3.DeviceConfiguration<_i3.DeviceRegistration>>);
-
-  @override
-  set deployment(_i3.PrimaryDeviceDeployment? _deployment) => super.noSuchMethod(
-        Invocation.setter(
-          #deployment,
-          _deployment,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set deviceRegistry(_i3.DeviceDataCollectorFactory? _deviceRegistry) => super.noSuchMethod(
-        Invocation.setter(
-          #deviceRegistry,
-          _deviceRegistry,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set deploymentService(_i3.DeploymentService? _deploymentService) => super.noSuchMethod(
-        Invocation.setter(
-          #deploymentService,
-          _deploymentService,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set deploymentStatus(_i3.StudyDeploymentStatus? _deploymentStatus) => super.noSuchMethod(
-        Invocation.setter(
-          #deploymentStatus,
-          _deploymentStatus,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set status(_i3.StudyStatus? newStatus) => super.noSuchMethod(
-        Invocation.setter(
-          #status,
-          newStatus,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i7.Stream<_i3.Measurement> measurementsByType(String? type) => (super.noSuchMethod(
-        Invocation.method(
-          #measurementsByType,
-          [type],
-        ),
-        returnValue: _i7.Stream<_i3.Measurement>.empty(),
-        returnValueForMissingStub: _i7.Stream<_i3.Measurement>.empty(),
-      ) as _i7.Stream<_i3.Measurement>);
-
-  @override
-  _i7.Future<void> configure({
-    _i2.DataEndPoint? dataEndPoint,
-    _i2.DataTransformer? transformer,
-  }) =>
+  _i2.SmartphoneStudy get study =>
       (super.noSuchMethod(
-        Invocation.method(
-          #configure,
-          [],
-          {
-            #dataEndPoint: dataEndPoint,
-            #transformer: transformer,
-          },
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+            Invocation.getter(#study),
+            returnValue: _FakeSmartphoneStudy_0(this, Invocation.getter(#study)),
+            returnValueForMissingStub: _FakeSmartphoneStudy_0(this, Invocation.getter(#study)),
+          )
+          as _i2.SmartphoneStudy);
 
   @override
-  _i7.Future<void> askForAllPermissions() => (super.noSuchMethod(
-        Invocation.method(
-          #askForAllPermissions,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  void initializeDevices() => super.noSuchMethod(
-        Invocation.method(
-          #initializeDevices,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void initializeDevice(_i3.DeviceConfiguration<_i3.DeviceRegistration>? configuration) => super.noSuchMethod(
-        Invocation.method(
-          #initializeDevice,
-          [configuration],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void startHeartbeatMonitoring() => super.noSuchMethod(
-        Invocation.method(
-          #startHeartbeatMonitoring,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i7.Future<void> connectAllConnectableDevices() => (super.noSuchMethod(
-        Invocation.method(
-          #connectAllConnectableDevices,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  _i7.Future<_i3.StudyStatus> tryDeployment({bool? useCached = true}) => (super.noSuchMethod(
-        Invocation.method(
-          #tryDeployment,
-          [],
-          {#useCached: useCached},
-        ),
-        returnValue: _i7.Future<_i3.StudyStatus>.value(_i3.StudyStatus.DeploymentNotStarted),
-        returnValueForMissingStub: _i7.Future<_i3.StudyStatus>.value(_i3.StudyStatus.DeploymentNotStarted),
-      ) as _i7.Future<_i3.StudyStatus>);
-
-  @override
-  _i7.Future<bool> saveDeployment() => (super.noSuchMethod(
-        Invocation.method(
-          #saveDeployment,
-          [],
-        ),
-        returnValue: _i7.Future<bool>.value(false),
-        returnValueForMissingStub: _i7.Future<bool>.value(false),
-      ) as _i7.Future<bool>);
-
-  @override
-  _i7.Future<bool> restoreDeployment() => (super.noSuchMethod(
-        Invocation.method(
-          #restoreDeployment,
-          [],
-        ),
-        returnValue: _i7.Future<bool>.value(false),
-        returnValueForMissingStub: _i7.Future<bool>.value(false),
-      ) as _i7.Future<bool>);
-
-  @override
-  _i7.Future<void> eraseDeployment() => (super.noSuchMethod(
-        Invocation.method(
-          #eraseDeployment,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  _i7.Future<void> start([bool? start = true]) => (super.noSuchMethod(
-        Invocation.method(
-          #start,
-          [start],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  _i7.Future<void> stop() => (super.noSuchMethod(
-        Invocation.method(
-          #stop,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  _i7.Future<void> remove() => (super.noSuchMethod(
-        Invocation.method(
-          #remove,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i7.Future<void> addStudy(
-    _i3.Study? study,
-    _i3.DeviceRegistration? deviceRegistration,
-  ) =>
+  List<_i4.DeviceConfiguration<_i4.DeviceRegistration>> get remainingDevicesToRegister =>
       (super.noSuchMethod(
-        Invocation.method(
-          #addStudy,
-          [
-            study,
-            deviceRegistration,
-          ],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+            Invocation.getter(#remainingDevicesToRegister),
+            returnValue: <_i4.DeviceConfiguration<_i4.DeviceRegistration>>[],
+            returnValueForMissingStub: <_i4.DeviceConfiguration<_i4.DeviceRegistration>>[],
+          )
+          as List<_i4.DeviceConfiguration<_i4.DeviceRegistration>>);
 
   @override
-  _i7.Future<_i3.StudyDeploymentStatus?> getStudyDeploymentStatus() => (super.noSuchMethod(
-        Invocation.method(
-          #getStudyDeploymentStatus,
-          [],
-        ),
-        returnValue: _i7.Future<_i3.StudyDeploymentStatus?>.value(),
-        returnValueForMissingStub: _i7.Future<_i3.StudyDeploymentStatus?>.value(),
-      ) as _i7.Future<_i3.StudyDeploymentStatus?>);
-
-  @override
-  _i7.Future<void> tryRegisterConnectedDevice(_i3.DeviceConfiguration<_i3.DeviceRegistration>? device) =>
+  Map<_i5.Permission, _i5.PermissionStatus> get permissions =>
       (super.noSuchMethod(
-        Invocation.method(
-          #tryRegisterConnectedDevice,
-          [device],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+            Invocation.getter(#permissions),
+            returnValue: <_i5.Permission, _i5.PermissionStatus>{},
+            returnValueForMissingStub: <_i5.Permission, _i5.PermissionStatus>{},
+          )
+          as Map<_i5.Permission, _i5.PermissionStatus>);
 
   @override
-  _i7.Future<void> tryRegisterRemainingDevicesToRegister() => (super.noSuchMethod(
-        Invocation.method(
-          #tryRegisterRemainingDevicesToRegister,
-          [],
-        ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+  _i2.SmartphoneDeploymentExecutor get executor =>
+      (super.noSuchMethod(
+            Invocation.getter(#executor),
+            returnValue: _FakeSmartphoneDeploymentExecutor_1(this, Invocation.getter(#executor)),
+            returnValueForMissingStub: _FakeSmartphoneDeploymentExecutor_1(this, Invocation.getter(#executor)),
+          )
+          as _i2.SmartphoneDeploymentExecutor);
+
+  @override
+  String get privacySchemaName =>
+      (super.noSuchMethod(
+            Invocation.getter(#privacySchemaName),
+            returnValue: _i6.dummyValue<String>(this, Invocation.getter(#privacySchemaName)),
+            returnValueForMissingStub: _i6.dummyValue<String>(this, Invocation.getter(#privacySchemaName)),
+          )
+          as String);
+
+  @override
+  _i7.Stream<_i4.Measurement> get measurements =>
+      (super.noSuchMethod(
+            Invocation.getter(#measurements),
+            returnValue: _i7.Stream<_i4.Measurement>.empty(),
+            returnValueForMissingStub: _i7.Stream<_i4.Measurement>.empty(),
+          )
+          as _i7.Stream<_i4.Measurement>);
+
+  @override
+  _i7.Stream<_i4.Measurement> measurementsByType(String? type) =>
+      (super.noSuchMethod(
+            Invocation.method(#measurementsByType, [type]),
+            returnValue: _i7.Stream<_i4.Measurement>.empty(),
+            returnValueForMissingStub: _i7.Stream<_i4.Measurement>.empty(),
+          )
+          as _i7.Stream<_i4.Measurement>);
+
+  @override
+  _i7.Future<void> tryRegisterConnectedDevice(_i4.DeviceConfiguration<_i4.DeviceRegistration>? device) =>
+      (super.noSuchMethod(
+            Invocation.method(#tryRegisterConnectedDevice, [device]),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> tryRegisterRemainingDevicesToRegister() =>
+      (super.noSuchMethod(
+            Invocation.method(#tryRegisterRemainingDevicesToRegister, []),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> tryUnregisterDisconnectedDevice(_i4.DeviceConfiguration<_i4.DeviceRegistration>? device) =>
+      (super.noSuchMethod(
+            Invocation.method(#tryUnregisterDisconnectedDevice, [device]),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> tryReregisterDevice(_i4.DeviceConfiguration<_i4.DeviceRegistration>? device) =>
+      (super.noSuchMethod(
+            Invocation.method(#tryReregisterDevice, [device]),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> askForAllPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#askForAllPermissions, []),
+            returnValue: _i7.Future<void>.value(),
+            returnValueForMissingStub: _i7.Future<void>.value(),
+          )
+          as _i7.Future<void>);
+
+  @override
+  void restart() => super.noSuchMethod(Invocation.method(#restart, []), returnValueForMissingStub: null);
+
+  @override
+  void resume() => super.noSuchMethod(Invocation.method(#resume, []), returnValueForMissingStub: null);
+
+  @override
+  void pause() => super.noSuchMethod(Invocation.method(#pause, []), returnValueForMissingStub: null);
+
+  @override
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
 }
 
 /// A class which mocks [HeartRateCardViewModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHeartRateCardViewModel extends _i1.Mock implements _i4.HeartRateCardViewModel {
+class MockHeartRateCardViewModel extends _i1.Mock implements _i3.HeartRateCardViewModel {
   @override
-  Map<int, _i4.HeartRateMinMaxPrHour> get hourlyHeartRate => (super.noSuchMethod(
-        Invocation.getter(#hourlyHeartRate),
-        returnValue: <int, _i4.HeartRateMinMaxPrHour>{},
-        returnValueForMissingStub: <int, _i4.HeartRateMinMaxPrHour>{},
-      ) as Map<int, _i4.HeartRateMinMaxPrHour>);
+  Map<int, _i3.HeartRateMinMaxPrHour> get hourlyHeartRate =>
+      (super.noSuchMethod(
+            Invocation.getter(#hourlyHeartRate),
+            returnValue: <int, _i3.HeartRateMinMaxPrHour>{},
+            returnValueForMissingStub: <int, _i3.HeartRateMinMaxPrHour>{},
+          )
+          as Map<int, _i3.HeartRateMinMaxPrHour>);
 
   @override
-  _i4.HeartRateMinMaxPrHour get dayMinMax => (super.noSuchMethod(
-        Invocation.getter(#dayMinMax),
-        returnValue: _FakeHeartRateMinMaxPrHour_4(
-          this,
-          Invocation.getter(#dayMinMax),
-        ),
-        returnValueForMissingStub: _FakeHeartRateMinMaxPrHour_4(
-          this,
-          Invocation.getter(#dayMinMax),
-        ),
-      ) as _i4.HeartRateMinMaxPrHour);
+  _i3.HeartRateMinMaxPrHour get dayMinMax =>
+      (super.noSuchMethod(
+            Invocation.getter(#dayMinMax),
+            returnValue: _FakeHeartRateMinMaxPrHour_2(this, Invocation.getter(#dayMinMax)),
+            returnValueForMissingStub: _FakeHeartRateMinMaxPrHour_2(this, Invocation.getter(#dayMinMax)),
+          )
+          as _i3.HeartRateMinMaxPrHour);
 
   @override
-  _i4.HourlyHeartRate get model => (super.noSuchMethod(
-        Invocation.getter(#model),
-        returnValue: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.getter(#model),
-        ),
-        returnValueForMissingStub: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.getter(#model),
-        ),
-      ) as _i4.HourlyHeartRate);
+  _i3.HourlyHeartRate get model =>
+      (super.noSuchMethod(
+            Invocation.getter(#model),
+            returnValue: _FakeHourlyHeartRate_3(this, Invocation.getter(#model)),
+            returnValueForMissingStub: _FakeHourlyHeartRate_3(this, Invocation.getter(#model)),
+          )
+          as _i3.HourlyHeartRate);
 
   @override
-  _i7.Future<String> get filename => (super.noSuchMethod(
-        Invocation.getter(#filename),
-        returnValue: _i7.Future<String>.value(_i6.dummyValue<String>(
-          this,
-          Invocation.getter(#filename),
-        )),
-        returnValueForMissingStub: _i7.Future<String>.value(_i6.dummyValue<String>(
-          this,
-          Invocation.getter(#filename),
-        )),
-      ) as _i7.Future<String>);
+  _i7.Future<String> get filename =>
+      (super.noSuchMethod(
+            Invocation.getter(#filename),
+            returnValue: _i7.Future<String>.value(_i6.dummyValue<String>(this, Invocation.getter(#filename))),
+            returnValueForMissingStub: _i7.Future<String>.value(
+              _i6.dummyValue<String>(this, Invocation.getter(#filename)),
+            ),
+          )
+          as _i7.Future<String>);
 
   @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get hasListeners =>
+      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false, returnValueForMissingStub: false)
+          as bool);
 
   @override
-  _i4.HourlyHeartRate createModel() => (super.noSuchMethod(
-        Invocation.method(
-          #createModel,
-          [],
-        ),
-        returnValue: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #createModel,
-            [],
-          ),
-        ),
-        returnValueForMissingStub: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #createModel,
-            [],
-          ),
-        ),
-      ) as _i4.HourlyHeartRate);
+  _i3.HourlyHeartRate createModel() =>
+      (super.noSuchMethod(
+            Invocation.method(#createModel, []),
+            returnValue: _FakeHourlyHeartRate_3(this, Invocation.method(#createModel, [])),
+            returnValueForMissingStub: _FakeHourlyHeartRate_3(this, Invocation.method(#createModel, [])),
+          )
+          as _i3.HourlyHeartRate);
 
   @override
-  void init(_i2.SmartphoneDeploymentController? ctrl) => super.noSuchMethod(
-        Invocation.method(
-          #init,
-          [ctrl],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void init(_i2.SmartphoneStudyController? ctrl) =>
+      super.noSuchMethod(Invocation.method(#init, [ctrl]), returnValueForMissingStub: null);
 
   @override
-  void clear() => super.noSuchMethod(
-        Invocation.method(
-          #clear,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void clear() => super.noSuchMethod(Invocation.method(#clear, []), returnValueForMissingStub: null);
 
   @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
 
   @override
-  _i7.Future<bool> save() => (super.noSuchMethod(
-        Invocation.method(
-          #save,
-          [],
-        ),
-        returnValue: _i7.Future<bool>.value(false),
-        returnValueForMissingStub: _i7.Future<bool>.value(false),
-      ) as _i7.Future<bool>);
+  _i7.Future<bool> save() =>
+      (super.noSuchMethod(
+            Invocation.method(#save, []),
+            returnValue: _i7.Future<bool>.value(false),
+            returnValueForMissingStub: _i7.Future<bool>.value(false),
+          )
+          as _i7.Future<bool>);
 
   @override
-  bool delete() => (super.noSuchMethod(
-        Invocation.method(
-          #delete,
-          [],
-        ),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool delete() =>
+      (super.noSuchMethod(Invocation.method(#delete, []), returnValue: false, returnValueForMissingStub: false)
+          as bool);
 
   @override
-  _i7.Future<_i4.HourlyHeartRate?> restore() => (super.noSuchMethod(
-        Invocation.method(
-          #restore,
-          [],
-        ),
-        returnValue: _i7.Future<_i4.HourlyHeartRate?>.value(),
-        returnValueForMissingStub: _i7.Future<_i4.HourlyHeartRate?>.value(),
-      ) as _i7.Future<_i4.HourlyHeartRate?>);
+  _i7.Future<_i3.HourlyHeartRate?> restore() =>
+      (super.noSuchMethod(
+            Invocation.method(#restore, []),
+            returnValue: _i7.Future<_i3.HourlyHeartRate?>.value(),
+            returnValueForMissingStub: _i7.Future<_i3.HourlyHeartRate?>.value(),
+          )
+          as _i7.Future<_i3.HourlyHeartRate?>);
 
   @override
-  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void addListener(_i8.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#addListener, [listener]), returnValueForMissingStub: null);
 
   @override
-  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void removeListener(_i8.VoidCallback? listener) =>
+      super.noSuchMethod(Invocation.method(#removeListener, [listener]), returnValueForMissingStub: null);
 
   @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
+  void notifyListeners() =>
+      super.noSuchMethod(Invocation.method(#notifyListeners, []), returnValueForMissingStub: null);
 }
 
 /// A class which mocks [HourlyHeartRate].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHourlyHeartRate extends _i1.Mock implements _i4.HourlyHeartRate {
+class MockHourlyHeartRate extends _i1.Mock implements _i3.HourlyHeartRate {
   @override
-  Map<int, _i4.HeartRateMinMaxPrHour> get hourlyHeartRate => (super.noSuchMethod(
-        Invocation.getter(#hourlyHeartRate),
-        returnValue: <int, _i4.HeartRateMinMaxPrHour>{},
-        returnValueForMissingStub: <int, _i4.HeartRateMinMaxPrHour>{},
-      ) as Map<int, _i4.HeartRateMinMaxPrHour>);
-
-  @override
-  DateTime get lastUpdated => (super.noSuchMethod(
-        Invocation.getter(#lastUpdated),
-        returnValue: _FakeDateTime_6(
-          this,
-          Invocation.getter(#lastUpdated),
-        ),
-        returnValueForMissingStub: _FakeDateTime_6(
-          this,
-          Invocation.getter(#lastUpdated),
-        ),
-      ) as DateTime);
-
-  @override
-  set hourlyHeartRate(Map<int, _i4.HeartRateMinMaxPrHour>? _hourlyHeartRate) => super.noSuchMethod(
-        Invocation.setter(
-          #hourlyHeartRate,
-          _hourlyHeartRate,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set lastUpdated(DateTime? _lastUpdated) => super.noSuchMethod(
-        Invocation.setter(
-          #lastUpdated,
-          _lastUpdated,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set currentHeartRate(double? _currentHeartRate) => super.noSuchMethod(
-        Invocation.setter(
-          #currentHeartRate,
-          _currentHeartRate,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set maxHeartRate(double? _maxHeartRate) => super.noSuchMethod(
-        Invocation.setter(
-          #maxHeartRate,
-          _maxHeartRate,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set minHeartRate(double? _minHeartRate) => super.noSuchMethod(
-        Invocation.setter(
-          #minHeartRate,
-          _minHeartRate,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i4.HourlyHeartRate resetDataAtMidnight() => (super.noSuchMethod(
-        Invocation.method(
-          #resetDataAtMidnight,
-          [],
-        ),
-        returnValue: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #resetDataAtMidnight,
-            [],
-          ),
-        ),
-        returnValueForMissingStub: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #resetDataAtMidnight,
-            [],
-          ),
-        ),
-      ) as _i4.HourlyHeartRate);
-
-  @override
-  _i4.HourlyHeartRate addHeartRate(
-    int? hour,
-    double? heartRate,
-  ) =>
+  Map<int, _i3.HeartRateMinMaxPrHour> get hourlyHeartRate =>
       (super.noSuchMethod(
-        Invocation.method(
-          #addHeartRate,
-          [
-            hour,
-            heartRate,
-          ],
-        ),
-        returnValue: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #addHeartRate,
-            [
-              hour,
-              heartRate,
-            ],
-          ),
-        ),
-        returnValueForMissingStub: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #addHeartRate,
-            [
-              hour,
-              heartRate,
-            ],
-          ),
-        ),
-      ) as _i4.HourlyHeartRate);
+            Invocation.getter(#hourlyHeartRate),
+            returnValue: <int, _i3.HeartRateMinMaxPrHour>{},
+            returnValueForMissingStub: <int, _i3.HeartRateMinMaxPrHour>{},
+          )
+          as Map<int, _i3.HeartRateMinMaxPrHour>);
 
   @override
-  _i4.HourlyHeartRate fromJson(Map<String, dynamic>? json) => (super.noSuchMethod(
-        Invocation.method(
-          #fromJson,
-          [json],
-        ),
-        returnValue: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #fromJson,
-            [json],
-          ),
-        ),
-        returnValueForMissingStub: _FakeHourlyHeartRate_5(
-          this,
-          Invocation.method(
-            #fromJson,
-            [json],
-          ),
-        ),
-      ) as _i4.HourlyHeartRate);
+  DateTime get lastUpdated =>
+      (super.noSuchMethod(
+            Invocation.getter(#lastUpdated),
+            returnValue: _FakeDateTime_4(this, Invocation.getter(#lastUpdated)),
+            returnValueForMissingStub: _FakeDateTime_4(this, Invocation.getter(#lastUpdated)),
+          )
+          as DateTime);
 
   @override
-  Map<String, dynamic> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-        returnValueForMissingStub: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  set hourlyHeartRate(Map<int, _i3.HeartRateMinMaxPrHour>? value) =>
+      super.noSuchMethod(Invocation.setter(#hourlyHeartRate, value), returnValueForMissingStub: null);
+
+  @override
+  set lastUpdated(DateTime? value) =>
+      super.noSuchMethod(Invocation.setter(#lastUpdated, value), returnValueForMissingStub: null);
+
+  @override
+  set currentHeartRate(double? value) =>
+      super.noSuchMethod(Invocation.setter(#currentHeartRate, value), returnValueForMissingStub: null);
+
+  @override
+  set maxHeartRate(double? value) =>
+      super.noSuchMethod(Invocation.setter(#maxHeartRate, value), returnValueForMissingStub: null);
+
+  @override
+  set minHeartRate(double? value) =>
+      super.noSuchMethod(Invocation.setter(#minHeartRate, value), returnValueForMissingStub: null);
+
+  @override
+  _i3.HourlyHeartRate resetDataAtMidnight() =>
+      (super.noSuchMethod(
+            Invocation.method(#resetDataAtMidnight, []),
+            returnValue: _FakeHourlyHeartRate_3(this, Invocation.method(#resetDataAtMidnight, [])),
+            returnValueForMissingStub: _FakeHourlyHeartRate_3(this, Invocation.method(#resetDataAtMidnight, [])),
+          )
+          as _i3.HourlyHeartRate);
+
+  @override
+  _i3.HourlyHeartRate addHeartRate(int? hour, double? heartRate) =>
+      (super.noSuchMethod(
+            Invocation.method(#addHeartRate, [hour, heartRate]),
+            returnValue: _FakeHourlyHeartRate_3(this, Invocation.method(#addHeartRate, [hour, heartRate])),
+            returnValueForMissingStub: _FakeHourlyHeartRate_3(
+              this,
+              Invocation.method(#addHeartRate, [hour, heartRate]),
+            ),
+          )
+          as _i3.HourlyHeartRate);
+
+  @override
+  _i3.HourlyHeartRate fromJson(Map<String, dynamic>? json) =>
+      (super.noSuchMethod(
+            Invocation.method(#fromJson, [json]),
+            returnValue: _FakeHourlyHeartRate_3(this, Invocation.method(#fromJson, [json])),
+            returnValueForMissingStub: _FakeHourlyHeartRate_3(this, Invocation.method(#fromJson, [json])),
+          )
+          as _i3.HourlyHeartRate);
+
+  @override
+  Map<String, dynamic> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, dynamic>{},
+            returnValueForMissingStub: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [PolarHRSample].
@@ -827,42 +375,35 @@ class MockHourlyHeartRate extends _i1.Mock implements _i4.HourlyHeartRate {
 /// See the documentation for Mockito's code generation for more information.
 class MockPolarHRSample extends _i1.Mock implements _i9.PolarHRSample {
   @override
-  int get hr => (super.noSuchMethod(
-        Invocation.getter(#hr),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
+  int get hr => (super.noSuchMethod(Invocation.getter(#hr), returnValue: 0, returnValueForMissingStub: 0) as int);
 
   @override
-  List<int> get rrsMs => (super.noSuchMethod(
-        Invocation.getter(#rrsMs),
-        returnValue: <int>[],
-        returnValueForMissingStub: <int>[],
-      ) as List<int>);
+  List<int> get rrsMs =>
+      (super.noSuchMethod(Invocation.getter(#rrsMs), returnValue: <int>[], returnValueForMissingStub: <int>[])
+          as List<int>);
 
   @override
-  bool get contactStatus => (super.noSuchMethod(
-        Invocation.getter(#contactStatus),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get contactStatus =>
+      (super.noSuchMethod(Invocation.getter(#contactStatus), returnValue: false, returnValueForMissingStub: false)
+          as bool);
 
   @override
-  bool get contactStatusSupported => (super.noSuchMethod(
-        Invocation.getter(#contactStatusSupported),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool get contactStatusSupported =>
+      (super.noSuchMethod(
+            Invocation.getter(#contactStatusSupported),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 
   @override
-  Map<String, dynamic> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-        returnValueForMissingStub: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, dynamic>{},
+            returnValueForMissingStub: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [PolarHR].
@@ -870,201 +411,133 @@ class MockPolarHRSample extends _i1.Mock implements _i9.PolarHRSample {
 /// See the documentation for Mockito's code generation for more information.
 class MockPolarHR extends _i1.Mock implements _i9.PolarHR {
   @override
-  Function get fromJsonFunction => (super.noSuchMethod(
-        Invocation.getter(#fromJsonFunction),
-        returnValue: () {},
-        returnValueForMissingStub: () {},
-      ) as Function);
+  Function get fromJsonFunction =>
+      (super.noSuchMethod(Invocation.getter(#fromJsonFunction), returnValue: () {}, returnValueForMissingStub: () {})
+          as Function);
 
   @override
-  String get jsonType => (super.noSuchMethod(
-        Invocation.getter(#jsonType),
-        returnValue: _i6.dummyValue<String>(
-          this,
-          Invocation.getter(#jsonType),
-        ),
-        returnValueForMissingStub: _i6.dummyValue<String>(
-          this,
-          Invocation.getter(#jsonType),
-        ),
-      ) as String);
+  String get jsonType =>
+      (super.noSuchMethod(
+            Invocation.getter(#jsonType),
+            returnValue: _i6.dummyValue<String>(this, Invocation.getter(#jsonType)),
+            returnValueForMissingStub: _i6.dummyValue<String>(this, Invocation.getter(#jsonType)),
+          )
+          as String);
 
   @override
-  List<_i9.PolarHRSample> get samples => (super.noSuchMethod(
-        Invocation.getter(#samples),
-        returnValue: <_i9.PolarHRSample>[],
-        returnValueForMissingStub: <_i9.PolarHRSample>[],
-      ) as List<_i9.PolarHRSample>);
+  List<_i9.PolarHRSample> get samples =>
+      (super.noSuchMethod(
+            Invocation.getter(#samples),
+            returnValue: <_i9.PolarHRSample>[],
+            returnValueForMissingStub: <_i9.PolarHRSample>[],
+          )
+          as List<_i9.PolarHRSample>);
 
   @override
-  set sensorSpecificData(_i3.Data? _sensorSpecificData) => super.noSuchMethod(
-        Invocation.setter(
-          #sensorSpecificData,
-          _sensorSpecificData,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set sensorSpecificData(_i4.Data? value) =>
+      super.noSuchMethod(Invocation.setter(#sensorSpecificData, value), returnValueForMissingStub: null);
 
   @override
-  _i3.DataType get format => (super.noSuchMethod(
-        Invocation.getter(#format),
-        returnValue: _FakeDataType_7(
-          this,
-          Invocation.getter(#format),
-        ),
-        returnValueForMissingStub: _FakeDataType_7(
-          this,
-          Invocation.getter(#format),
-        ),
-      ) as _i3.DataType);
+  _i4.DataType get dataType =>
+      (super.noSuchMethod(
+            Invocation.getter(#dataType),
+            returnValue: _FakeDataType_5(this, Invocation.getter(#dataType)),
+            returnValueForMissingStub: _FakeDataType_5(this, Invocation.getter(#dataType)),
+          )
+          as _i4.DataType);
 
   @override
-  set $type(String? _$type) => super.noSuchMethod(
-        Invocation.setter(
-          #$type,
-          _$type,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set $type(String? value) => super.noSuchMethod(Invocation.setter(#$type, value), returnValueForMissingStub: null);
 
   @override
-  Map<String, dynamic> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-        returnValueForMissingStub: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, dynamic>{},
+            returnValueForMissingStub: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 
   @override
-  bool equivalentTo(_i3.Data? other) => (super.noSuchMethod(
-        Invocation.method(
-          #equivalentTo,
-          [other],
-        ),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
+  bool equivalentTo(_i4.Data? other) =>
+      (super.noSuchMethod(
+            Invocation.method(#equivalentTo, [other]),
+            returnValue: false,
+            returnValueForMissingStub: false,
+          )
+          as bool);
 }
 
 /// A class which mocks [Measurement].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMeasurement extends _i1.Mock implements _i3.Measurement {
+class MockMeasurement extends _i1.Mock implements _i4.Measurement {
   @override
-  int get sensorStartTime => (super.noSuchMethod(
-        Invocation.getter(#sensorStartTime),
-        returnValue: 0,
-        returnValueForMissingStub: 0,
-      ) as int);
+  int get sensorStartTime =>
+      (super.noSuchMethod(Invocation.getter(#sensorStartTime), returnValue: 0, returnValueForMissingStub: 0) as int);
 
   @override
-  _i3.Data get data => (super.noSuchMethod(
-        Invocation.getter(#data),
-        returnValue: _FakeData_2(
-          this,
-          Invocation.getter(#data),
-        ),
-        returnValueForMissingStub: _FakeData_2(
-          this,
-          Invocation.getter(#data),
-        ),
-      ) as _i3.Data);
+  _i4.DataType get dataType =>
+      (super.noSuchMethod(
+            Invocation.getter(#dataType),
+            returnValue: _FakeDataType_5(this, Invocation.getter(#dataType)),
+            returnValueForMissingStub: _FakeDataType_5(this, Invocation.getter(#dataType)),
+          )
+          as _i4.DataType);
 
   @override
-  _i3.DataType get dataType => (super.noSuchMethod(
-        Invocation.getter(#dataType),
-        returnValue: _FakeDataType_7(
-          this,
-          Invocation.getter(#dataType),
-        ),
-        returnValueForMissingStub: _FakeDataType_7(
-          this,
-          Invocation.getter(#dataType),
-        ),
-      ) as _i3.DataType);
+  _i4.Data get data =>
+      (super.noSuchMethod(
+            Invocation.getter(#data),
+            returnValue: _FakeData_6(this, Invocation.getter(#data)),
+            returnValueForMissingStub: _FakeData_6(this, Invocation.getter(#data)),
+          )
+          as _i4.Data);
 
   @override
-  set sensorStartTime(int? _sensorStartTime) => super.noSuchMethod(
-        Invocation.setter(
-          #sensorStartTime,
-          _sensorStartTime,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set sensorStartTime(int? value) =>
+      super.noSuchMethod(Invocation.setter(#sensorStartTime, value), returnValueForMissingStub: null);
 
   @override
-  set sensorEndTime(int? _sensorEndTime) => super.noSuchMethod(
-        Invocation.setter(
-          #sensorEndTime,
-          _sensorEndTime,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set sensorEndTime(int? value) =>
+      super.noSuchMethod(Invocation.setter(#sensorEndTime, value), returnValueForMissingStub: null);
 
   @override
-  set taskControl(_i3.TaskControl? _taskControl) => super.noSuchMethod(
-        Invocation.setter(
-          #taskControl,
-          _taskControl,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set taskControl(_i4.TaskControl? value) =>
+      super.noSuchMethod(Invocation.setter(#taskControl, value), returnValueForMissingStub: null);
 
   @override
-  set data(_i3.Data? _data) => super.noSuchMethod(
-        Invocation.setter(
-          #data,
-          _data,
-        ),
-        returnValueForMissingStub: null,
-      );
+  set data(_i4.Data? value) => super.noSuchMethod(Invocation.setter(#data, value), returnValueForMissingStub: null);
 
   @override
-  Map<String, dynamic> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-        returnValueForMissingStub: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, dynamic>{},
+            returnValueForMissingStub: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }
 
 /// A class which mocks [DataModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDataModel extends _i1.Mock implements _i4.DataModel {
+class MockDataModel extends _i1.Mock implements _i3.DataModel {
   @override
-  _i4.DataModel fromJson(Map<String, dynamic>? json) => (super.noSuchMethod(
-        Invocation.method(
-          #fromJson,
-          [json],
-        ),
-        returnValue: _FakeDataModel_8(
-          this,
-          Invocation.method(
-            #fromJson,
-            [json],
-          ),
-        ),
-        returnValueForMissingStub: _FakeDataModel_8(
-          this,
-          Invocation.method(
-            #fromJson,
-            [json],
-          ),
-        ),
-      ) as _i4.DataModel);
+  _i3.DataModel fromJson(Map<String, dynamic>? json) =>
+      (super.noSuchMethod(
+            Invocation.method(#fromJson, [json]),
+            returnValue: _FakeDataModel_7(this, Invocation.method(#fromJson, [json])),
+            returnValueForMissingStub: _FakeDataModel_7(this, Invocation.method(#fromJson, [json])),
+          )
+          as _i3.DataModel);
 
   @override
-  Map<String, dynamic> toJson() => (super.noSuchMethod(
-        Invocation.method(
-          #toJson,
-          [],
-        ),
-        returnValue: <String, dynamic>{},
-        returnValueForMissingStub: <String, dynamic>{},
-      ) as Map<String, dynamic>);
+  Map<String, dynamic> toJson() =>
+      (super.noSuchMethod(
+            Invocation.method(#toJson, []),
+            returnValue: <String, dynamic>{},
+            returnValueForMissingStub: <String, dynamic>{},
+          )
+          as Map<String, dynamic>);
 }


### PR DESCRIPTION
Implements the upgrade of the whole CARP stack from the **1.x** to the **2.x**
line (API level 2.0.0), per the plan in `docs/CAMS_2.x_MIGRATION_PLAN.md`.

Parent: #571 · Closes #601

## Status
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/ test/` → **0 errors** (3 non-fatal info lints, pre-existing style)
- `dart format --set-exit-if-changed lib/** test/**` → **clean**
- `flutter test` → **all pass**

Verified by compiling against the real 2.x packages — the actual surface was
larger than the plan's static estimate (~19 files, 113 analyzer errors), which
this PR resolves in full.

## Dependency bumps
carp_core 1.9→**2.1.2**, carp_mobile_sensing 1.13→**2.1.1**, carp_webservices
3.8→**4.0**, carp_backend 1.9→**2.0**, all sampling packages →**2.0** (health
→**4.0**), carp_serializable →2.0.1, cognition_package →1.7.0. Transitive:
connectivity_plus →7, permission_handler →12. **Dart SDK floor 3.2 → 3.8**
(required by carp 2.x codegen — see formatting note below).

## API adaptations
| Area | 1.x | 2.x |
|---|---|---|
| Controller | `SmartphoneDeploymentController` | `SmartphoneStudyController` |
| Lookup | `getStudyRuntime(id)` | `getStudyController(study)` |
| Deploy | `controller.tryDeployment(useCached:)` + `controller.configure()` | client `tryDeployment(id, role)`; auto-config |
| Run/stop | `start()` / `stop()` | `resume()` / `pause()` |
| State | `ExecutorState.started` | `ExecutorState.Resumed` |
| Remove | `removeStudy(id)` | `removeStudy(id, role)` |
| Configure | `configure(deviceController:)` | `configure(dataCollectorFactory:)` |
| Task types | `SurveyUserTask.*_TYPE`, `HealthUserTask.*`, `BackgroundSensingUserTask.*` | `AppTask.*` |
| Steps type | `SensorSamplingPackage.STEP_COUNT` | `CarpDataTypes.STEP_COUNT` |
| Input types | `AddressInput.type`, … | `InputType.ADDRESS`, … |
| Device | `.type` / `.id` | `.deviceType` / `.displayName` |
| Device status | `DeviceStatus.initialized` / `.error` | `.configured` / (removed) |
| BLE | `BTLEDeviceManager`, `btleName/btleAddress` | `BLEDeviceManager`, `bleName/bleAddress` |
| Online svc | `OnlineServiceManager` | `ServiceManager` |
| Polar/Movesense | `config.deviceType` | manager `polarDeviceType`/`movesenseDeviceType` |
| Participant | `deployment.participantId/RoleName` | `study.participantId/RoleName` |
| Primary device | `status.primaryDeviceStatus` | `deviceStatusList` (where `PrimaryDeviceConfiguration`) |
| Consent | `getInformedConsent/set/delete` | `getConsentDocument/setConsentDocument/deleteConsentDocument` |
| `samplingSize` | `controller.samplingSize` | derived locally |

`SmartphoneDeploymentController._saveDeployment()` calls were removed (2.x
persists device registrations automatically, matching the CAMS example app).

## Commits
1. **feat: migrate to CAMS 2.x** — all semantic + dependency changes.
2. **style: apply dart format tall style** — the SDK 3.8 bump switches the
   canonical `dart format` style to "tall", so the files *not* touched by the
   migration are reformatted here (no logic) so CI's format check passes.
   Reviewers can skip commit 2.

## Risks to validate on-device (from the plan)
- **Persistent runtime state** is new and on by default — confirm `leaveStudy`/
  `removeStudy` fully clears it (testers should reinstall between 1.x↔2.x builds).
- **Steps card**: the smartphone pedometer now emits `StepEvent` while the card
  filters `StepCount` — verify the deployed protocol's step measure still yields
  `StepCount`, otherwise the steps card needs to switch to `StepEvent`.
- **carp_health 4.0**: re-run Health Connect / HealthKit permission flow.
- **DeviceStatus.error removed**: error states now fall through to `unknown`.
