### PR TITLE
chore(ci): bump Flutter 3.44.0 -> 3.44.6 in release workflows

### DIFF
--- a/.github/workflows/create_release_on_tag.yml
+++ b/.github/workflows/create_release_on_tag.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.6"
           channel: stable
           cache: true
           pub-cache: true

--- a/.github/workflows/deploy_to_google_play_store_fastlane_release.yml
+++ b/.github/workflows/deploy_to_google_play_store_fastlane_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.44.0"
+          flutter-version: "3.44.6"
           channel: stable
           cache: true
           pub-cache: true


### PR DESCRIPTION
Pins the two release workflows to Flutter **3.44.6** (was 3.44.0), matching the version used locally and for the current release.

- `create_release_on_tag.yml`
- `deploy_to_google_play_store_fastlane_release.yml`