### PR TITLE
chore: bump version to 4.4.1 for hotfix release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: carp_study_app
 description: The generic CARP study app.
 publish_to: "none"
-version: 4.4.0+1
+version: 4.4.1+1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,8 @@
 name: carp_study_app
 description: The generic CARP study app.
 publish_to: "none"
+# Bump only the version name for a release; the `+N` build number is ignored by CI
+# (Fastlane auto-increments the Play versionCode; iOS uses the Xcode Cloud build number).
 version: 4.4.1+1
 
 environment:


### PR DESCRIPTION
Bumps the app version name `4.4.0` → `4.4.1` for the upcoming hotfix release.