### PR TITLE
chore(android): remove unused Health Connect permissions (Play policy, Routing ID ZLFS)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,31 +70,14 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <!-- Permissions for Health Connect API -->
-    <!-- Basic body measurements -->
-    <uses-permission android:name="android.permission.health.READ_WEIGHT" />
-    <uses-permission android:name="android.permission.health.READ_HEIGHT" />
-    <uses-permission android:name="android.permission.health.READ_BODY_FAT" />
-
     <!-- Activity (ACTIVITY_RECOGNITION declared above) -->
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />
-    <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />
-    <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
 
-    <!-- Vital signs for cardiology, diabetes, and sleep studies -->
+    <!-- Vital signs -->
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
-    <uses-permission android:name="android.permission.health.READ_BLOOD_PRESSURE" />
-    <uses-permission android:name="android.permission.health.READ_OXYGEN_SATURATION" />
-    <uses-permission android:name="android.permission.health.READ_HEART_RATE_VARIABILITY" />
-    <uses-permission android:name="android.permission.health.READ_RESPIRATORY_RATE" />
-    <uses-permission android:name="android.permission.health.READ_BLOOD_GLUCOSE" />
-    <uses-permission android:name="android.permission.health.READ_BODY_TEMPERATURE" />
     <uses-permission android:name="android.permission.health.READ_SKIN_TEMPERATURE" />
-
-    <!-- Sleep -->
-    <uses-permission android:name="android.permission.health.READ_SLEEP" />
-    <uses-permission android:name="android.permission.health.READ_RESTING_HEART_RATE" />
 
     <!-- Historical data (older than 30 days since permission granted) -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />


### PR DESCRIPTION
Fixes the Google Play **Health Connect Permissions** policy rejection (Routing ID `ZLFS`, App Bundle Version Code 139, Production).

## Why

Play review flagged *"Excessive data access for declared features"* — the manifest declared 13 Health Connect read permissions that no code in the app ever reads. Play requires the minimum necessary scopes, and every requested permission must be demonstrably critical to functionality.

## What

Removes the exact 13 permissions Play listed, from `android/app/src/main/AndroidManifest.xml`:

| Removed | Play-listed type |
|---|---|
| `READ_ACTIVE_CALORIES_BURNED` | ActiveCaloriesBurned |
| `READ_TOTAL_CALORIES_BURNED` | TotalCaloriesBurned |
| `READ_BLOOD_GLUCOSE` | BloodGlucose |
| `READ_BLOOD_PRESSURE` | BloodPressure |
| `READ_BODY_FAT` | BodyFat |
| `READ_BODY_TEMPERATURE` | BodyTemperature |
| `READ_HEIGHT` | Height |
| `READ_WEIGHT` | Weight |
| `READ_HEART_RATE_VARIABILITY` | HeartRateVariabilityRmssd |
| `READ_OXYGEN_SATURATION` | OxygenSaturation |
| `READ_RESPIRATORY_RATE` | RespiratoryRate |
| `READ_RESTING_HEART_RATE` | RestingHeartRate |
| `READ_SLEEP` | SleepSession |

## Justification for what is kept

| Kept | Critical to |
|---|---|
| `READ_STEPS` | Steps card on the Statistics page |
| `READ_DISTANCE` | Distance shown alongside steps |
| `READ_HEART_RATE` | Heart rate card; core to the cardiology study protocols |
| `READ_SKIN_TEMPERATURE` | Collected by supported wearables in active study protocols |
| `READ_HEALTH_DATA_HISTORY` | Study protocols backfill data recorded before enrolment |
| `READ_HEALTH_DATA_IN_BACKGROUND` | Studies sample continuously; the app is not foreground during a study |

## Verification

- No Dart, asset or resource code references any removed type (grepped `lib/`, `assets/`, `android/`) — removal is manifest-only, nothing breaks at runtime.
- `debug` and `profile` manifests never declared health permissions.
- Manifest XML parses clean.

## Follow-up outside this PR

- [ ] Update the **Health Connect declaration form** in Play Console so the selected data types match this shorter list — the manifest alone will not clear the rejection.
- [ ] Play requires the removal in **all tracks**, not just Production: check Internal/Closed/Open testing for bundles still carrying the old list, and roll out a new release at 100% to deactivate version code 139.
- [ ] Confirm the four kept data permissions are each visibly justified in-app (permission rationale screen), as the notice requires.